### PR TITLE
Added support for net472

### DIFF
--- a/KS.Fiks.ASiC-E/KS.Fiks.ASiC-E.csproj
+++ b/KS.Fiks.ASiC-E/KS.Fiks.ASiC-E.csproj
@@ -15,7 +15,7 @@
     <PackageIconUrl>https://ks-no.github.io/images/favicon.png</PackageIconUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>FIKS</PackageTags>
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net472</TargetFrameworks>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>


### PR DESCRIPTION
Added support for net472. 
When publishing to Cloud Services (Classic) in Azure the app will not run if you publish using netstandard packages, and .net core is not an option.