### PR TITLE
Target netstandard2.0 in addition to 2.1 and netcore3.1

### DIFF
--- a/KS.Fiks.ASiC-E/Crypto/ICertificateHolder.cs
+++ b/KS.Fiks.ASiC-E/Crypto/ICertificateHolder.cs
@@ -81,8 +81,10 @@ namespace KS.Fiks.ASiC_E.Crypto
 
         private static PemObject ReadPem(byte[] pemString)
         {
-            using var pemPublicStringReader = new StringReader(Encoding.UTF8.GetString(pemString));
-            return new PemReader(pemPublicStringReader).ReadPemObject();
+            using (var pemPublicStringReader = new StringReader(Encoding.UTF8.GetString(pemString)))
+            {
+                return new PemReader(pemPublicStringReader).ReadPemObject();
+            }
         }
     }
 }

--- a/KS.Fiks.ASiC-E/KS.Fiks.ASiC-E.csproj
+++ b/KS.Fiks.ASiC-E/KS.Fiks.ASiC-E.csproj
@@ -16,7 +16,7 @@
     <PackageIcon>favicon.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>FIKS</PackageTags>
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>

--- a/KS.Fiks.ASiC-E/Manifest/CadesManifestReader.cs
+++ b/KS.Fiks.ASiC-E/Manifest/CadesManifestReader.cs
@@ -37,12 +37,10 @@ namespace KS.Fiks.ASiC_E.Manifest
                 var xmlString = streamReader.ReadToEnd()
                     .Replace(
                         "http://uri.etsi.org/02918/v1.2.1#",
-                        Namespaces.CadesAsicNamespace,
-                        StringComparison.CurrentCulture)
+                        Namespaces.CadesAsicNamespace)
                     .Replace(
                         "http://uri.etsi.org/02918/v1.1.1#",
-                        Namespaces.CadesAsicNamespace,
-                        StringComparison.CurrentCulture);
+                        Namespaces.CadesAsicNamespace);
                 return new StringReader(xmlString);
             }
         }


### PR DESCRIPTION
In order to be compliant with certain azure configurations (see #10), we should re-add netstandard2.0 to the list of target frameworks﻿
