### PR TITLE
Added the option to specify a root file.

### DIFF
--- a/KS.Fiks.ASiC-E.Test/AsiceBuilderTest.cs
+++ b/KS.Fiks.ASiC-E.Test/AsiceBuilderTest.cs
@@ -11,7 +11,6 @@ namespace KS.Fiks.ASiC_E.Test
 {
     public class AsiceBuilderTest : IClassFixture<LogFixture>
     {
-
         private readonly LogFixture logFixture;
 
         public AsiceBuilderTest(LogFixture logFixture)
@@ -62,6 +61,56 @@ namespace KS.Fiks.ASiC_E.Test
             {
                 zipArchive.Entries.Count.Should().Be(4);
             }
+        }
+
+        [Fact(DisplayName = "When a container entry is marked as root file, the container manifest must contain that root file.")]
+        public void SetFileAsRoot_ManifestContainsRootFile()
+        {
+            byte[] archive;
+
+            var signingCertificates = TestdataLoader.ReadCertificatesForTest();
+            using (var outStream = new MemoryStream())
+            {
+                using var fileStream = File.OpenRead("small.pdf");
+                using (var asiceBuilder = AsiceBuilder.Create(outStream, MessageDigestAlgorithm.SHA256, signingCertificates))
+                {
+                    asiceBuilder.AddFile(fileStream, true);
+                    asiceBuilder.Build();
+                }
+
+                archive = outStream.ToArray();
+            }
+
+            using var inStream = new MemoryStream(archive);
+            IAsicReader reader = new AsiceReader();
+            using var asice = reader.Read(inStream);
+
+            asice.CadesManifest.RootFile.Should().Be("small.pdf");
+        }
+
+        [Fact(DisplayName = "When no container entry is marked as root file, the container manifest must not contain any root file.")]
+        public void FileNotSetAsRoot_ManifestContainsNoRootFile()
+        {
+            byte[] archive;
+
+            var signingCertificates = TestdataLoader.ReadCertificatesForTest();
+            using (var outStream = new MemoryStream())
+            {
+                using var fileStream = File.OpenRead("small.pdf");
+                using (var asiceBuilder = AsiceBuilder.Create(outStream, MessageDigestAlgorithm.SHA256, signingCertificates))
+                {
+                    asiceBuilder.AddFile(fileStream);
+                    asiceBuilder.Build();
+                }
+
+                archive = outStream.ToArray();
+            }
+
+            using var inStream = new MemoryStream(archive);
+            IAsicReader reader = new AsiceReader();
+            using var asice = reader.Read(inStream);
+
+            asice.CadesManifest.RootFile.Should().BeNullOrEmpty();
         }
     }
 }

--- a/KS.Fiks.ASiC-E/AsiceBuilder.cs
+++ b/KS.Fiks.ASiC-E/AsiceBuilder.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Xml;
 using KS.Fiks.ASiC_E.Crypto;
 using KS.Fiks.ASiC_E.Manifest;
 using KS.Fiks.ASiC_E.Model;
@@ -34,7 +33,7 @@ namespace KS.Fiks.ASiC_E
         {
             var outStream = stream ?? throw new ArgumentNullException(nameof(stream));
             var algorithm = messageDigestAlgorithm ?? throw new ArgumentNullException(nameof(messageDigestAlgorithm));
-            if (! outStream.CanWrite)
+            if (!outStream.CanWrite)
             {
                 throw new ArgumentException("The provided Stream must be writable", nameof(stream));
             }
@@ -56,14 +55,30 @@ namespace KS.Fiks.ASiC_E
             return AddFile(file, file.Name);
         }
 
+        public IAsiceBuilder<AsiceArchive> AddFile(FileStream file, bool rootFile)
+        {
+            return AddFile(file, file.Name, rootFile);
+        }
+
         public IAsiceBuilder<AsiceArchive> AddFile(Stream stream, string filename)
         {
             return AddFile(stream, filename, MimeTypeExtractor.ExtractMimeType(filename));
         }
 
+        public IAsiceBuilder<AsiceArchive> AddFile(Stream stream, string filename, bool rootFile)
+        {
+            return AddFile(stream, filename, MimeTypeExtractor.ExtractMimeType(filename), rootFile);
+        }
+
         public IAsiceBuilder<AsiceArchive> AddFile(Stream stream, string filename, MimeType mimeType)
         {
             this.asiceArchive.AddEntry(stream, new FileRef(Path.GetFileName(filename), mimeType));
+            return this;
+        }
+
+        public IAsiceBuilder<AsiceArchive> AddFile(Stream stream, string filename, MimeType mimeType, bool rootFile)
+        {
+            this.asiceArchive.AddEntry(stream, new FileRef(Path.GetFileName(filename), mimeType), rootFile);
             return this;
         }
 

--- a/KS.Fiks.ASiC-E/IAsiceBuilder.cs
+++ b/KS.Fiks.ASiC-E/IAsiceBuilder.cs
@@ -29,5 +29,24 @@ namespace KS.Fiks.ASiC_E
         /// <param name="mimeType">The MIME type of the given file</param>
         /// <returns>The same builder with the given file added</returns>
         IAsiceBuilder<T> AddFile(Stream stream, string filename, MimeType mimeType);
+
+        /// <summary>
+        /// Add a stream of data with a given filename to the ASiC-E package. MIME type will be derived from the filename extension.
+        /// </summary>
+        /// <param name="stream">The stream to read the data from</param>
+        /// <param name="filename">The filename of the file to be added</param>
+        /// <param name="rootFile">A value indicating whether the specified file is the container's root file.</param>
+        /// <returns>The same builder with the given file added</returns>
+        IAsiceBuilder<T> AddFile(Stream stream, string filename, bool rootFile);
+
+        /// <summary>
+        /// Add a stream of data with a given filename and MIME type to the ASiC-E package.
+        /// </summary>
+        /// <param name="stream">The stream to read the data from</param>
+        /// <param name="filename">The filename of the file to be added</param>
+        /// <param name="mimeType">The MIME type of the given file</param>
+        /// <param name="rootFile">A value indicating whether the specified file is the container's root file.</param>
+        /// <returns>The same builder with the given file added</returns>
+        IAsiceBuilder<T> AddFile(Stream stream, string filename, MimeType mimeType, bool rootFile);
     }
 }

--- a/KS.Fiks.ASiC-E/KS.Fiks.ASiC-E.csproj
+++ b/KS.Fiks.ASiC-E/KS.Fiks.ASiC-E.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.0.4</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     
     <RootNamespace>KS.Fiks.ASiC_E</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/KS.Fiks.ASiC-E/KS.Fiks.ASiC-E.csproj
+++ b/KS.Fiks.ASiC-E/KS.Fiks.ASiC-E.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.1.0-beta.0</VersionPrefix>
     
     <RootNamespace>KS.Fiks.ASiC_E</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/KS.Fiks.ASiC-E/Manifest/CadesManifestCreator.cs
+++ b/KS.Fiks.ASiC-E/Manifest/CadesManifestCreator.cs
@@ -34,7 +34,10 @@ namespace KS.Fiks.ASiC_E.Manifest
 
         public ManifestContainer CreateManifest(IEnumerable<AsicePackageEntry> entries)
         {
-            var manifest = new ASiCManifestType { DataObjectReference = entries.Select(ToDataObject).ToArray() };
+            var hasRootFile = false;
+            var dataObjectReference = entries.Select(e => ToDataObject(e, ref hasRootFile)).ToArray();
+            var manifest = new ASiCManifestType { DataObjectReference = dataObjectReference };
+
             SignatureFileRef signatureFileRef = null;
             if (addSignatureFile)
             {
@@ -79,11 +82,17 @@ namespace KS.Fiks.ASiC_E.Manifest
             return ns;
         }
 
-        private static DataObjectReferenceType ToDataObject(AsicePackageEntry packageEntry)
+        private static DataObjectReferenceType ToDataObject(AsicePackageEntry packageEntry, ref bool hasRootFile)
         {
             if (packageEntry == null)
             {
                 return null;
+            }
+
+            var isRootFile = !hasRootFile && packageEntry.RootFile;
+            if (isRootFile)
+            {
+                hasRootFile = true;
             }
 
             return new DataObjectReferenceType
@@ -94,7 +103,9 @@ namespace KS.Fiks.ASiC_E.Manifest
                     Algorithm = packageEntry.MessageDigestAlgorithm.Uri.ToString()
                 },
                 DigestValue = packageEntry.Digest.GetDigest(),
-                URI = packageEntry.FileName
+                URI = packageEntry.FileName,
+                Rootfile = isRootFile,
+                RootfileSpecified = isRootFile,
             };
         }
     }

--- a/KS.Fiks.ASiC-E/Model/AsiceArchive.cs
+++ b/KS.Fiks.ASiC-E/Model/AsiceArchive.cs
@@ -19,7 +19,7 @@ namespace KS.Fiks.ASiC_E.Model
 
         private ICertificateHolder SignatureCertificate { get; }
 
-        private ZipArchive Archive { get;  }
+        private ZipArchive Archive { get; }
 
         private readonly Queue<AsicePackageEntry> entries = new Queue<AsicePackageEntry>();
 
@@ -57,10 +57,11 @@ namespace KS.Fiks.ASiC_E.Model
         /// </summary>
         /// <param name="contentStream">The stream that contains the data</param>
         /// <param name="entry">A description of the file entry</param>
+        /// <param name="rootFile">A value indicating whether the specified file is the container's root file.</param>
         /// <returns>The archive with the entry added</returns>
         /// <exception cref="ArgumentException">If any if the parameters is null or invalid.
         /// Only files that are not in the /META-INF may be added</exception>
-        public AsiceArchive AddEntry(Stream contentStream, FileRef entry)
+        public AsiceArchive AddEntry(Stream contentStream, FileRef entry, bool rootFile = false)
         {
             var packageEntry = entry ?? throw new ArgumentNullException(nameof(entry), "Entry must be provided");
             if (packageEntry.FileName.StartsWith("META-INF/", StringComparison.CurrentCultureIgnoreCase))
@@ -70,7 +71,7 @@ namespace KS.Fiks.ASiC_E.Model
 
             Log.Debug($"Adding entry '{entry.FileName}' of type '{entry.MimeType}' to the ASiC-e archive");
 
-            this.entries.Enqueue(CreateEntry(contentStream, new AsicePackageEntry(entry.FileName, entry.MimeType, MessageDigestAlgorithm)));
+            this.entries.Enqueue(CreateEntry(contentStream, new AsicePackageEntry(entry.FileName, entry.MimeType, MessageDigestAlgorithm, rootFile)));
             return this;
         }
 

--- a/KS.Fiks.ASiC-E/Model/AsicePackageEntry.cs
+++ b/KS.Fiks.ASiC-E/Model/AsicePackageEntry.cs
@@ -10,14 +10,17 @@ namespace KS.Fiks.ASiC_E.Model
 
         public MessageDigestAlgorithm MessageDigestAlgorithm { get; }
 
+        public bool RootFile { get; }
+
         public DigestContainer Digest { get; set; }
 
-        public AsicePackageEntry(string fileName, MimeType type, MessageDigestAlgorithm messageDigestAlgorithm)
+        public AsicePackageEntry(string fileName, MimeType type, MessageDigestAlgorithm messageDigestAlgorithm, bool rootFile = false)
         {
             FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
             Type = type ?? throw new ArgumentNullException(nameof(type));
             MessageDigestAlgorithm = messageDigestAlgorithm ??
                                      throw new ArgumentNullException(nameof(messageDigestAlgorithm));
+            RootFile = rootFile;
         }
     }
 }


### PR DESCRIPTION
The proposed changes allow users to add files to the ASiC container and set them as root files. To achieve that, new  overloads of `IAsiceBuilder<T>.AddFile()` have been added that contain the parameter `bool rootFile`. The changes to the code are compatible to previews versions.

Example:

```csharp
using var fileStream = File.OpenRead("small.pdf");
using (var asiceBuilder = AsiceBuilder.Create(outStream, MessageDigestAlgorithm.SHA256, signingCertificates))
{
    asiceBuilder.AddFile(fileStream, true);
    asiceBuilder.Build();
}
```

Then, the manifest will reflect the root file:
```csharp
IAsicReader reader = new AsiceReader();
using(var asice = reader.Read(inStream))
{
    Console.WriteLine(asice.CadesManifest.RootFile); // Outputs "small.pdf"
}
```