### PR TITLE
Builder skal ikke stenge stream

### DIFF
--- a/KS.Fiks.ASiC-E.Test/KS.Fiks.ASiC-E.Test.csproj
+++ b/KS.Fiks.ASiC-E.Test/KS.Fiks.ASiC-E.Test.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>KS.Fiks.ASiC_E.Test</RootNamespace>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/KS.Fiks.ASiC-E.Test/Model/AsiceArchiveTest.cs
+++ b/KS.Fiks.ASiC-E.Test/Model/AsiceArchiveTest.cs
@@ -97,5 +97,87 @@ namespace KS.Fiks.ASiC_E.Test.Model
 
             this.log.Info($"Wrote package to '{tempFileName}'");
         }
+
+        [Fact(DisplayName = "Create ASiC-E package and add manifest manually")]
+        public void CreateArchiveWithReuseOfZippedOutStream()
+        {
+            using (var zippedOutStream = new MemoryStream())
+            {
+                using (var archive = AsiceArchive.Create(
+                           zippedOutStream,
+                           CadesManifestCreator.CreateWithSignatureFile(),
+                           TestdataLoader.ReadCertificatesForTest()))
+                using (var fileStream = File.OpenRead(FileNameTestPdf))
+                {
+                    archive.AddEntry(
+                        fileStream,
+                        new FileRef(FileNameTestPdf, MimeType.ForString(MimeTypes.GetMimeType(FileNameTestPdf))));
+                }
+
+                var zippedData = zippedOutStream.ToArray();
+                zippedData.Should().NotBeNull();
+                zippedData.Should().HaveCountGreaterThan(0);
+
+                Assert.True(zippedOutStream.CanSeek);
+                zippedOutStream.Seek(0, SeekOrigin.Begin);
+
+                using (var zippedArchive = new ZipArchive(zippedOutStream, ZipArchiveMode.Read, leaveOpen: true))
+                {
+                    zippedArchive.Entries.Should().HaveCount(4);
+                    zippedArchive.Entries
+                        .First(e => e.FullName.Equals(FileNameTestPdf, StringComparison.CurrentCulture)).Should()
+                        .NotBeNull();
+                    zippedArchive.Entries.First(e =>
+                            e.FullName.Equals(AsiceConstants.CadesManifestFilename, StringComparison.CurrentCulture))
+                        .Should().NotBeNull();
+                    zippedArchive.Entries.First(e =>
+                            e.FullName.Equals(AsiceConstants.FileNameMimeType, StringComparison.CurrentCulture))
+                        .Should()
+                        .NotBeNull();
+
+                    var mimeTypeEntry = zippedArchive.GetEntry(AsiceConstants.FileNameMimeType);
+                    using (var entryStream = mimeTypeEntry.Open())
+                    using (var copyStream = new MemoryStream())
+                    {
+                        entryStream.CopyTo(copyStream);
+                        Encoding.UTF8.GetString(copyStream.ToArray()).Should().Be(AsiceConstants.ContentTypeASiCe);
+                    }
+
+                    // Verifies that a CADES manifest has been generated
+                    using (var entryStream = zippedArchive.GetEntry(AsiceConstants.CadesManifestFilename).Open())
+                    using (var copyStream = new MemoryStream())
+                    {
+                        entryStream.CopyTo(copyStream);
+
+                        var manifestXml = Encoding.UTF8.GetString(copyStream.ToArray());
+                        manifestXml.Should().NotBeNull();
+                        this.log.Info($"Manifest: {manifestXml}");
+                    }
+
+                    var signatureFile = zippedArchive.Entries
+                        .First(e => e.FullName.StartsWith("META-INF", StringComparison.CurrentCulture) &&
+                                    e.FullName.EndsWith(".p7s", StringComparison.CurrentCulture));
+                    signatureFile.Should().NotBeNull();
+
+                    // Verifies the signature file
+                    using (var entryStream = signatureFile.Open())
+                    using (var copyStream = new MemoryStream())
+                    {
+                        entryStream.CopyTo(copyStream);
+                        var signatureContent = copyStream.ToArray();
+                        signatureContent.Should().HaveCountGreaterThan(0);
+                    }
+                }
+
+                var tempFileName = Path.GetTempFileName();
+                zippedOutStream.Seek(0, SeekOrigin.Begin);
+                using (var outputFileStream = File.OpenWrite(tempFileName))
+                {
+                    zippedOutStream.CopyTo(outputFileStream);
+                }
+
+                this.log.Info($"Wrote package to '{tempFileName}'");
+            }
+        }
     }
 }

--- a/KS.Fiks.ASiC-E/AsiceBuilder.cs
+++ b/KS.Fiks.ASiC-E/AsiceBuilder.cs
@@ -66,12 +66,6 @@ namespace KS.Fiks.ASiC_E
             asiceArchive.AddEntry(stream, new FileRef(Path.GetFileName(filename), mimeType));
             return this;
         }
-        
-        public IAsiceBuilder<AsiceArchive> AddManifest()
-        {
-            asiceArchive.AddManifest();
-            return this;
-        }
 
         public void Dispose()
         {

--- a/KS.Fiks.ASiC-E/AsiceBuilder.cs
+++ b/KS.Fiks.ASiC-E/AsiceBuilder.cs
@@ -48,7 +48,7 @@ namespace KS.Fiks.ASiC_E
         public AsiceArchive Build()
         {
 
-            return this.asiceArchive;
+            return asiceArchive;
         }
 
         public IAsiceBuilder<AsiceArchive> AddFile(FileStream file)
@@ -63,19 +63,19 @@ namespace KS.Fiks.ASiC_E
 
         public IAsiceBuilder<AsiceArchive> AddFile(Stream stream, string filename, MimeType mimeType)
         {
-            this.asiceArchive.AddEntry(stream, new FileRef(Path.GetFileName(filename), mimeType));
+            asiceArchive.AddEntry(stream, new FileRef(Path.GetFileName(filename), mimeType));
             return this;
         }
         
-        public IAsiceBuilder<AsiceArchive> Finalize()
+        public IAsiceBuilder<AsiceArchive> AddManifest()
         {
-            this.asiceArchive.Finalize();
+            asiceArchive.AddManifest();
             return this;
         }
 
         public void Dispose()
         {
-            this.asiceArchive.Dispose();
+            asiceArchive.Dispose();
         }
     }
 }

--- a/KS.Fiks.ASiC-E/AsiceBuilder.cs
+++ b/KS.Fiks.ASiC-E/AsiceBuilder.cs
@@ -66,6 +66,12 @@ namespace KS.Fiks.ASiC_E
             this.asiceArchive.AddEntry(stream, new FileRef(Path.GetFileName(filename), mimeType));
             return this;
         }
+        
+        public IAsiceBuilder<AsiceArchive> Finalize()
+        {
+            this.asiceArchive.Finalize();
+            return this;
+        }
 
         public void Dispose()
         {

--- a/KS.Fiks.ASiC-E/Model/AsiceArchive.cs
+++ b/KS.Fiks.ASiC-E/Model/AsiceArchive.cs
@@ -25,7 +25,7 @@ namespace KS.Fiks.ASiC_E.Model
 
         private readonly IManifestCreator manifestCreator;
 
-        private bool IsFinalized = false;
+        private bool ManifestAdded;
 
         private MessageDigestAlgorithm MessageDigestAlgorithm { get; }
 
@@ -64,7 +64,7 @@ namespace KS.Fiks.ASiC_E.Model
         /// Only files that are not in the /META-INF may be added</exception>
         public AsiceArchive AddEntry(Stream contentStream, FileRef entry)
         {
-            if (IsFinalized)
+            if (ManifestAdded)
             {
                 throw new ArgumentException("Adding files to a finalized builder is not allowed.");
             }
@@ -94,16 +94,6 @@ namespace KS.Fiks.ASiC_E.Model
             Archive.Dispose();
         }
 
-        public void Finalize()
-        {
-            if (IsFinalized)
-            {
-                return;
-            }
-
-            AddManifest();
-        }
-
         private AsicePackageEntry CreateEntry(Stream contentStream, AsicePackageEntry entry)
         {
             var fileName = entry.FileName ?? throw new ArgumentNullException(nameof(entry), "File name must be provided");
@@ -120,10 +110,11 @@ namespace KS.Fiks.ASiC_E.Model
             return entry;
         }
 
-        private void AddManifest()
+        public void AddManifest()
         {
-            if (IsFinalized)
+            if (ManifestAdded)
             {
+                Log.Debug("Manifest already added to archive");
                 return;
             }
 
@@ -148,7 +139,7 @@ namespace KS.Fiks.ASiC_E.Model
                 CreateEntry(manifestStream, new AsicePackageEntry(manifest.FileName, MimeType.ForString(AsiceConstants.ContentTypeXml), MessageDigestAlgorithm));
             }
 
-            IsFinalized = true;
+            ManifestAdded = true;
             Log.Debug("Manifest added to archive");
         }
 


### PR DESCRIPTION
Builder skal ikke lenger "levere" en stengt stream 

Løst ved at vi oppretter ZipArchive med leaveOpen på streams.
Testet ut først mulighet ved å legge til manifest selv, ikke bare ved dispose av builder. Men det viste seg at problemet lå egentlig i opprettelse av ZipArchive.
Dette er for å slippe å måtte kopiere en closed stream til array før man kan lage ny stream igjen når man bruker dette biblioteket. I denne PR'en testes det ut: https://github.com/ks-no/fiks-io-client-dotnet/pull/116