### PR TITLE
Oppdaterer dependencies

### DIFF
--- a/KS.Fiks.ASiC-E.Test/KS.Fiks.ASiC-E.Test.csproj
+++ b/KS.Fiks.ASiC-E.Test/KS.Fiks.ASiC-E.Test.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="NLog" Version="5.2.5" />
+    <PackageReference Include="NLog" Version="5.2.8" />
     <PackageReference Include="xunit" Version="2.6.1" />
     <PackageReference Include="xunit.analyzers" Version="1.5.0" PrivateAssets="All" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">

--- a/KS.Fiks.ASiC-E.Test/KS.Fiks.ASiC-E.Test.csproj
+++ b/KS.Fiks.ASiC-E.Test/KS.Fiks.ASiC-E.Test.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="NLog" Version="5.2.5" />
     <PackageReference Include="xunit" Version="2.6.1" />
     <PackageReference Include="xunit.analyzers" Version="1.5.0" PrivateAssets="All" />

--- a/KS.Fiks.ASiC-E.Test/KS.Fiks.ASiC-E.Test.csproj
+++ b/KS.Fiks.ASiC-E.Test/KS.Fiks.ASiC-E.Test.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="NLog" Version="5.2.5" />
     <PackageReference Include="xunit" Version="2.6.1" />

--- a/KS.Fiks.ASiC-E.Test/KS.Fiks.ASiC-E.Test.csproj
+++ b/KS.Fiks.ASiC-E.Test/KS.Fiks.ASiC-E.Test.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="NLog" Version="5.2.8" />
-    <PackageReference Include="xunit" Version="2.6.1" />
-    <PackageReference Include="xunit.analyzers" Version="1.5.0" PrivateAssets="All" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.analyzers" Version="1.10.0" PrivateAssets="All" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/KS.Fiks.ASiC-E/KS.Fiks.ASiC-E.csproj
+++ b/KS.Fiks.ASiC-E/KS.Fiks.ASiC-E.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="MimeMapping" Version="2.0.0" />
     <PackageReference Include="NLog" Version="5.2.5" />
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/KS.Fiks.ASiC-E/KS.Fiks.ASiC-E.csproj
+++ b/KS.Fiks.ASiC-E/KS.Fiks.ASiC-E.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>        
 
   <ItemGroup>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.3.0" />
     <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="MimeMapping" Version="2.0.0" />
     <PackageReference Include="NLog" Version="5.2.5" />

--- a/KS.Fiks.ASiC-E/KS.Fiks.ASiC-E.csproj
+++ b/KS.Fiks.ASiC-E/KS.Fiks.ASiC-E.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="MimeMapping" Version="2.0.0" />
     <PackageReference Include="NLog" Version="5.2.8" />
-    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/KS.Fiks.ASiC-E/KS.Fiks.ASiC-E.csproj
+++ b/KS.Fiks.ASiC-E/KS.Fiks.ASiC-E.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.3.0" />
     <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="MimeMapping" Version="2.0.0" />
-    <PackageReference Include="NLog" Version="5.2.5" />
+    <PackageReference Include="NLog" Version="5.2.8" />
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
- **Bump System.Collections.Immutable from 7.0.0 to 8.0.0**
- **Bump Microsoft.SourceLink.GitHub from 1.1.1 to 8.0.0**
- **Bump Moq from 4.20.69 to 4.20.70**
- **Bump NLog from 5.2.5 to 5.2.8**
- **Bump xunit.analyzers from 1.5.0 to 1.10.0**
- **Bump xunit from 2.6.1 to 2.6.6**
- **Bump BouncyCastle.Cryptography from 2.2.1 to 2.3.0**
- **Bump Microsoft.NET.Test.Sdk from 17.8.0 to 17.9.0**
