### PR TITLE
Remove Assembly and File Version

### DIFF
--- a/KS.Fiks.ASiC-E.Test/KS.Fiks.ASiC-E.Test.csproj
+++ b/KS.Fiks.ASiC-E.Test/KS.Fiks.ASiC-E.Test.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="FluentAssertions" Version="6.12.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.analyzers" Version="1.16.0" PrivateAssets="All" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>

--- a/KS.Fiks.ASiC-E/KS.Fiks.ASiC-E.csproj
+++ b/KS.Fiks.ASiC-E/KS.Fiks.ASiC-E.csproj
@@ -19,8 +19,6 @@
     <TargetFrameworks>net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>


### PR DESCRIPTION
Får feil i prosjekt som bruker pakker som igjen bruker KS.Fiks.ASiC-E-pakken. 

> The type 'PreloadedCertificateHolder' is defined in an assembly that is not referenced. You must add a reference to assembly 'KS.Fiks.ASiC-E, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f601fbcfd61fc565'.

AssemblyVersion og FileVersion blir ikke bumpet sammen med VersionPrefix, så disse fjernes for å defaulte til samme version som VersionPrefix.