### PR TITLE
Erstatte fluent assertions

### DIFF
--- a/KS.Fiks.ASiC-E.Test/AsiceBuilderTest.cs
+++ b/KS.Fiks.ASiC-E.Test/AsiceBuilderTest.cs
@@ -1,11 +1,10 @@
 using System;
 using System.IO;
 using System.IO.Compression;
-using System.Runtime.InteropServices;
-using FluentAssertions;
 using KS.Fiks.ASiC_E.Crypto;
 using KS.Fiks.ASiC_E.Model;
 using Moq;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.ASiC_E.Test;
@@ -19,7 +18,7 @@ public class AsiceBuilderTest
         var certificate = new Mock<ICertificateHolder>();
         Action createFunction = () =>
             AsiceBuilder.Create(zipStream.Object, MessageDigestAlgorithm.SHA512, certificate.Object);
-        createFunction.Should().Throw<ArgumentException>();
+        createFunction.ShouldThrow<ArgumentException>();
         zipStream.VerifyGet(s => s.CanWrite);
         zipStream.VerifyNoOtherCalls();
     }
@@ -36,23 +35,23 @@ public class AsiceBuilderTest
             using (var asiceBuilder =
                    AsiceBuilder.Create(zipStream, MessageDigestAlgorithm.SHA256, signingCertificates))
             {
-                asiceBuilder.Should().NotBeNull();
+                asiceBuilder.ShouldNotBeNull();
 
-                asiceBuilder.AddFile(fileStream).Should().NotBeNull().And.BeOfType<AsiceBuilder>();
+                asiceBuilder.AddFile(fileStream).ShouldNotBeNull().ShouldBeOfType<AsiceBuilder>();
 
                 var asiceArchive = asiceBuilder.Build();
-                asiceArchive.Should().NotBeNull();
+                asiceArchive.ShouldNotBeNull();
             }
 
             zippedBytes = zipStream.ToArray();
         }
 
-        zippedBytes.Should().HaveCountGreaterThan(0);
+        zippedBytes.Length.ShouldBeGreaterThan(0);
 
         using (var zipStream = new MemoryStream(zippedBytes))
         using (var zipArchive = new ZipArchive(zipStream, ZipArchiveMode.Read))
         {
-            zipArchive.Entries.Count.Should().Be(4);
+            zipArchive.Entries.Count.ShouldBe(4);
         }
     }
 
@@ -71,24 +70,24 @@ public class AsiceBuilderTest
             using (var asiceBuilder =
                 AsiceBuilder.Create(zipStream, MessageDigestAlgorithm.SHA256, signingCertificates))
             {
-                asiceBuilder.Should().NotBeNull();
+                asiceBuilder.ShouldNotBeNull();
 
-                asiceBuilder.AddFileWithPath(fileStream, fullPath,  MimeTypeExtractor.ExtractMimeType("small.pdf")).Should().NotBeNull().And.BeOfType<AsiceBuilder>();
+                asiceBuilder.AddFileWithPath(fileStream, fullPath,  MimeTypeExtractor.ExtractMimeType("small.pdf")).ShouldNotBeNull().ShouldBeOfType<AsiceBuilder>();
 
                 var asiceArchive = asiceBuilder.Build();
-                asiceArchive.Should().NotBeNull();
+                asiceArchive.ShouldNotBeNull();
             }
 
             zippedBytes = zipStream.ToArray();
         }
 
-        zippedBytes.Should().HaveCountGreaterThan(0);
+        zippedBytes.Length.ShouldBeGreaterThan(0);
 
         using (var zipStream = new MemoryStream(zippedBytes))
         using (var zipArchive = new ZipArchive(zipStream, ZipArchiveMode.Read))
         {
-            zipArchive.Entries.Count.Should().Be(4);
-            zipArchive.Entries.Should().Contain(e => e.FullName == fullPath);
+            zipArchive.Entries.Count.ShouldBe(4);
+            zipArchive.Entries.ShouldContain(e => e.FullName == fullPath);
         }
     }
 }

--- a/KS.Fiks.ASiC-E.Test/AsiceReaderTest.cs
+++ b/KS.Fiks.ASiC-E.Test/AsiceReaderTest.cs
@@ -1,6 +1,6 @@
 using System.IO;
 using System.Linq;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.ASiC_E.Test
@@ -14,18 +14,18 @@ namespace KS.Fiks.ASiC_E.Test
             using (var inputStream = TestDataUtil.ReadValidAsiceCadesFromResource())
             using (var asice = reader.Read(inputStream))
             {
-                asice.Should().NotBeNull();
+                asice.ShouldNotBeNull();
                 foreach (var asiceReadEntry in asice.Entries)
                 {
                     using (var entryStream = asiceReadEntry.OpenStream())
                     using (var bufferStream = new MemoryStream())
                     {
                         entryStream.CopyTo(bufferStream);
-                        bufferStream.ToArray().Count().Should().BeGreaterThan(0);
+                        bufferStream.ToArray().Count().ShouldBeGreaterThan(0);
                     }
                 }
 
-                asice.DigestVerifier.Verification().AllValid.Should().BeTrue();
+                asice.DigestVerifier.Verification().AllValid.ShouldBeTrue();
             }
         }
     }

--- a/KS.Fiks.ASiC-E.Test/AsiceVerifierTest.cs
+++ b/KS.Fiks.ASiC-E.Test/AsiceVerifierTest.cs
@@ -1,5 +1,5 @@
 using System.IO;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.ASiC_E.Test
@@ -14,12 +14,12 @@ namespace KS.Fiks.ASiC_E.Test
             using (var inputStream = new MemoryStream(asiceArchive))
             {
                 var asicManifest = asiceVerifier.Verify(inputStream);
-                asicManifest.Should().NotBeNull();
-                asicManifest.certificate.Should().NotBeNull();
-                asicManifest.certificate.Length.Should().Be(1);
-                asicManifest.file.Should().NotBeNull();
-                asicManifest.file.Length.Should().Be(2);
-                asicManifest.rootfile.Should().BeNull();
+                asicManifest.ShouldNotBeNull();
+                asicManifest.certificate.ShouldNotBeNull();
+                asicManifest.certificate.Length.ShouldBe(1);
+                asicManifest.file.ShouldNotBeNull();
+                asicManifest.file.Length.ShouldBe(2);
+                asicManifest.rootfile.ShouldBeNull();
             }
         }
     }

--- a/KS.Fiks.ASiC-E.Test/Crypto/DigestVerifierTest.cs
+++ b/KS.Fiks.ASiC-E.Test/Crypto/DigestVerifierTest.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
-using FluentAssertions;
 using KS.Fiks.ASiC_E.Crypto;
 using KS.Fiks.ASiC_E.Model;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.ASiC_E.Test.Crypto
@@ -29,8 +29,8 @@ namespace KS.Fiks.ASiC_E.Test.Crypto
         {
             var digestVerifier = DigestVerifier.Create(ImmutableDictionary<string, DeclaredDigestFile>.Empty);
             var verification = digestVerifier.Verification();
-            verification.Should().NotBeNull();
-            verification.AllValid.Should().BeTrue();
+            verification.ShouldNotBeNull();
+            verification.AllValid.ShouldBeTrue();
         }
 
         [Fact(DisplayName = "Verify digest, multiple declared none received")]
@@ -40,8 +40,7 @@ namespace KS.Fiks.ASiC_E.Test.Crypto
 
             Func<DigestVerificationResult> action = () => digestVerifier.Verification();
 
-            action.Should().Throw<DigestVerificationException>().And.Message.Should()
-                .Be("Total number of files processed by the verifier was 0, but 2 files was declared");
+            action.ShouldThrow<DigestVerificationException>().Message.ShouldBe("Total number of files processed by the verifier was 0, but 2 files was declared");
         }
 
         [Fact(DisplayName = "Verify digest, two declared but only one checked")]
@@ -50,8 +49,7 @@ namespace KS.Fiks.ASiC_E.Test.Crypto
             var digestVerifier = CreateDigestVerifierForTest();
             digestVerifier.ReceiveDigest(FileOne.Name, FileOne.Digest.ToArray());
             Func<DigestVerificationResult> action = () => digestVerifier.Verification();
-            action.Should().Throw<DigestVerificationException>().And.Message.Should()
-                .Be("Total number of files processed by the verifier was 1, but 2 files was declared");
+            action.ShouldThrow<DigestVerificationException>().Message.ShouldBe("Total number of files processed by the verifier was 1, but 2 files was declared");
         }
 
         [Fact(DisplayName = "Verify digests, two declared and two checked but with non-matching digests")]
@@ -61,8 +59,8 @@ namespace KS.Fiks.ASiC_E.Test.Crypto
             digestVerifier.ReceiveDigest(FileOne.Name, FileTwo.Digest.ToArray());
             digestVerifier.ReceiveDigest(FileTwo.Name, FileOne.Digest.ToArray());
             var result = digestVerifier.Verification();
-            result.AllValid.Should().BeFalse();
-            result.InvalidElements.Count().Should().Be(2);
+            result.AllValid.ShouldBeFalse();
+            result.InvalidElements.Count().ShouldBe(2);
         }
 
         [Fact(DisplayName = "Verify digests, all checked and valid")]
@@ -72,9 +70,9 @@ namespace KS.Fiks.ASiC_E.Test.Crypto
             digestVerifier.ReceiveDigest(FileOne.Name, FileOne.Digest.ToArray());
             digestVerifier.ReceiveDigest(FileTwo.Name, FileTwo.Digest.ToArray());
             var result = digestVerifier.Verification();
-            result.AllValid.Should().BeTrue();
-            result.ValidElements.Count().Should().Be(2);
-            result.ValidElements.Should().Contain(FileOne.Name, FileTwo.Name);
+            result.AllValid.ShouldBeTrue();
+            result.ValidElements.Count().ShouldBe(2);
+            result.ValidElements.ShouldContain(FileOne.Name, FileTwo.Name);
         }
 
         private static DigestVerifier CreateDigestVerifierForTest()

--- a/KS.Fiks.ASiC-E.Test/KS.Fiks.ASiC-E.Test.csproj
+++ b/KS.Fiks.ASiC-E.Test/KS.Fiks.ASiC-E.Test.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.analyzers" Version="1.19.0" PrivateAssets="All" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">

--- a/KS.Fiks.ASiC-E.Test/KS.Fiks.ASiC-E.Test.csproj
+++ b/KS.Fiks.ASiC-E.Test/KS.Fiks.ASiC-E.Test.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.analyzers" Version="1.17.0" PrivateAssets="All" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.analyzers" Version="1.19.0" PrivateAssets="All" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/KS.Fiks.ASiC-E.Test/KS.Fiks.ASiC-E.Test.csproj
+++ b/KS.Fiks.ASiC-E.Test/KS.Fiks.ASiC-E.Test.csproj
@@ -10,9 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.analyzers" Version="1.17.0" PrivateAssets="All" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/KS.Fiks.ASiC-E.Test/Manifest/CadesManifestCreatorTest.cs
+++ b/KS.Fiks.ASiC-E.Test/Manifest/CadesManifestCreatorTest.cs
@@ -1,11 +1,10 @@
 using System.IO;
 using System.Linq;
 using System.Xml.Serialization;
-using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
-using FluentAssertions;
 using KS.Fiks.ASiC_E.Manifest;
 using KS.Fiks.ASiC_E.Model;
 using KS.Fiks.ASiC_E.Xsd;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.ASiC_E.Test.Manifest
@@ -21,21 +20,20 @@ namespace KS.Fiks.ASiC_E.Test.Manifest
             fileEntry.Digest = new DigestContainer(new byte[] { 0, 0, 1 }, digestAlgorithm);
             var entries = new[] { fileEntry };
             var manifest = cadesManifestCreator.CreateManifest(entries);
-            manifest.Should().NotBeNull()
-                .And
-                .BeOfType<ManifestContainer>();
-            manifest.Data.Should().NotBeNull();
-            manifest.FileName.Should().Be(AsiceConstants.CadesManifestFilename);
+            manifest.ShouldNotBeNull()
+                .ShouldBeOfType<ManifestContainer>();
+            manifest.Data.ShouldNotBeNull();
+            manifest.FileName.ShouldBe(AsiceConstants.CadesManifestFilename);
 
             var xmlManifest = DeserializeManifest(manifest.Data.ToArray());
-            xmlManifest.Should().NotBeNull();
-            xmlManifest.SigReference.Should().BeNull();
-            xmlManifest.DataObjectReference.Should().HaveCount(1);
-            var dataObjectRef = xmlManifest.DataObjectReference[0];
-            dataObjectRef.Should().NotBeNull();
-            dataObjectRef.MimeType.Should().Be(fileEntry.Type.ToString());
-            dataObjectRef.DigestValue.Should().Equal(fileEntry.Digest.GetDigest());
-            dataObjectRef.URI.Should().Be(fileEntry.FileName);
+            xmlManifest.ShouldNotBeNull();
+            xmlManifest.SigReference.ShouldBeNull();
+            xmlManifest.DataObjectReference.ShouldHaveSingleItem();
+            var dataObjectRef = xmlManifest.DataObjectReference.Single();
+            dataObjectRef.ShouldNotBeNull();
+            dataObjectRef.MimeType.ShouldBe(fileEntry.Type.ToString());
+            dataObjectRef.DigestValue.ShouldBe(fileEntry.Digest.GetDigest());
+            dataObjectRef.URI.ShouldBe(fileEntry.FileName);
         }
 
         [Fact(DisplayName = "Create CAdES manifest with signature")]
@@ -45,15 +43,13 @@ namespace KS.Fiks.ASiC_E.Test.Manifest
             var fileEntry = new AsicePackageEntry("my.pdf", MimeType.ForString("application/pdf"), MessageDigestAlgorithm.SHA256);
             fileEntry.Digest = new DigestContainer(new byte[] { 0, 0, 1 }, MessageDigestAlgorithm.SHA256);
             var manifest = cadesManifestCreator.CreateManifest(new[] { fileEntry });
-            manifest.Should().NotBeNull()
-                .And
-                .BeOfType<ManifestContainer>();
-            manifest.FileName.Should().Be(AsiceConstants.CadesManifestFilename);
+            manifest.ShouldNotBeNull().ShouldBeOfType<ManifestContainer>();
+            manifest.FileName.ShouldBe(AsiceConstants.CadesManifestFilename);
             var xmlManifest = DeserializeManifest(manifest.Data.ToArray());
-            xmlManifest.Should().NotBeNull();
-            xmlManifest.SigReference.Should().NotBeNull();
-            xmlManifest.SigReference.MimeType.Should().Be(AsiceConstants.ContentTypeSignature);
-            xmlManifest.DataObjectReference.Should().HaveCount(1);
+            xmlManifest.ShouldNotBeNull();
+            xmlManifest.SigReference.ShouldNotBeNull();
+            xmlManifest.SigReference.MimeType.ShouldBe(AsiceConstants.ContentTypeSignature);
+            xmlManifest.DataObjectReference.ShouldHaveSingleItem();
         }
 
         private static ASiCManifestType DeserializeManifest(byte[] data)

--- a/KS.Fiks.ASiC-E.Test/Manifest/CadesManifestReaderTest.cs
+++ b/KS.Fiks.ASiC-E.Test/Manifest/CadesManifestReaderTest.cs
@@ -1,9 +1,9 @@
 using System;
 using System.IO;
 using System.Text;
-using FluentAssertions;
 using KS.Fiks.ASiC_E.Manifest;
 using KS.Fiks.ASiC_E.Model;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.ASiC_E.Test.Manifest
@@ -29,9 +29,9 @@ namespace KS.Fiks.ASiC_E.Test.Manifest
             {
                 var cadesManifestReader = new CadesManifestReader();
                 var cadesManifest = cadesManifestReader.FromStream(inputStream);
-                cadesManifest.Should().NotBeNull();
-                cadesManifest.Digests.Count.Should().Be(2);
-                cadesManifest.SignatureFileRef.Should().NotBeNull();
+                cadesManifest.ShouldNotBeNull();
+                cadesManifest.Digests.Count.ShouldBe(2);
+                cadesManifest.SignatureFileRef.ShouldNotBeNull();
             }
         }
 
@@ -54,9 +54,9 @@ namespace KS.Fiks.ASiC_E.Test.Manifest
             {
                 var cadesManifestReader = new CadesManifestReader();
                 var cadesManifest = cadesManifestReader.FromStream(inputStream);
-                cadesManifest.Should().NotBeNull();
-                cadesManifest.Digests.Count.Should().Be(2);
-                cadesManifest.SignatureFileRef.Should().NotBeNull();
+                cadesManifest.ShouldNotBeNull();
+                cadesManifest.Digests.Count.ShouldBe(2);
+                cadesManifest.SignatureFileRef.ShouldNotBeNull();
             }
         }
 
@@ -79,9 +79,9 @@ namespace KS.Fiks.ASiC_E.Test.Manifest
             {
                 var cadesManifestReader = new CadesManifestReader();
                 var cadesManifest = cadesManifestReader.FromStream(inputStream);
-                cadesManifest.Should().NotBeNull();
-                cadesManifest.Digests.Count.Should().Be(2);
-                cadesManifest.SignatureFileRef.Should().NotBeNull();
+                cadesManifest.ShouldNotBeNull();
+                cadesManifest.Digests.Count.ShouldBe(2);
+                cadesManifest.SignatureFileRef.ShouldNotBeNull();
             }
         }
 
@@ -104,8 +104,7 @@ namespace KS.Fiks.ASiC_E.Test.Manifest
             {
                 var cadesManifestReader = new CadesManifestReader();
                 Func<CadesManifest> action = () => cadesManifestReader.FromStream(inputStream);
-                action.Should().Throw<ManifestReadException>().And.Message.Should()
-                    .Be(CadesManifestReader.ErrorMessageInvalidNamespace);
+                action.ShouldThrow<ManifestReadException>().Message.ShouldBe(CadesManifestReader.ErrorMessageInvalidNamespace);
             }
         }
     }

--- a/KS.Fiks.ASiC-E.Test/MimeTypeExtractorTest.cs
+++ b/KS.Fiks.ASiC-E.Test/MimeTypeExtractorTest.cs
@@ -1,6 +1,6 @@
 using System;
-using FluentAssertions;
 using KS.Fiks.ASiC_E.Model;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.ASiC_E.Test
@@ -18,11 +18,8 @@ namespace KS.Fiks.ASiC_E.Test
         {
             var type = MimeTypeExtractor.ExtractMimeType(fileName);
 
-            type.Should()
-                .NotBeNull()
-                .And
-                .BeOfType<MimeType>();
-            type.ToString().Should().Be(mimeType);
+            type.ShouldNotBeNull().ShouldBeOfType<MimeType>();
+            type.ToString().ShouldBe(mimeType);
         }
 
         [Fact(DisplayName = "Extract MIME type for PDF")]
@@ -30,12 +27,8 @@ namespace KS.Fiks.ASiC_E.Test
         {
             var pdfType = MimeTypeExtractor.ExtractMimeType("filename.pdf");
 
-            pdfType.Should()
-                .NotBeNull()
-                .And
-                .BeOfType<MimeType>();
-
-            pdfType.ToString().Should().Be("application/pdf");
+            pdfType.ShouldNotBeNull().ShouldBeOfType<MimeType>();
+            pdfType.ToString().ShouldBe("application/pdf");
         }
 
         [Theory(DisplayName = "Test MIME type extraction for unknown types (fallbacks to application/octet-stream)")]
@@ -45,19 +38,16 @@ namespace KS.Fiks.ASiC_E.Test
         public void TestIllegalMimeType(string fileName)
         {
             var type = MimeTypeExtractor.ExtractMimeType(fileName);
-            type.Should()
-                .NotBeNull()
-                .And
-                .BeOfType<MimeType>();
+            type.ShouldNotBeNull().ShouldBeOfType<MimeType>();
 
-            type.ToString().Should().Be(MimeMapping.MimeUtility.UnknownMimeType);
+            type.ToString().ShouldBe(MimeMapping.MimeUtility.UnknownMimeType);
         }
 
         [Fact(DisplayName = "Test using null")]
         public void TestNull()
         {
             Action action = () => MimeTypeExtractor.ExtractMimeType(null);
-            action.Should().Throw<ArgumentNullException>();
+            action.ShouldThrow<ArgumentNullException>();
         }
     }
 }

--- a/KS.Fiks.ASiC-E.Test/Model/AsiceReadModelTest.cs
+++ b/KS.Fiks.ASiC-E.Test/Model/AsiceReadModelTest.cs
@@ -3,8 +3,8 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Text;
-using FluentAssertions;
 using KS.Fiks.ASiC_E.Model;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.ASiC_E.Test.Model
@@ -23,7 +23,7 @@ namespace KS.Fiks.ASiC_E.Test.Model
                     using (var readArchive = new ZipArchive(zipInStream, ZipArchiveMode.Read))
                     {
                         Action createAction = () => new AsiceReadModel(readArchive);
-                        createAction.Should().Throw<ArgumentException>().And.ParamName.Should().Be("zipArchive");
+                        createAction.ShouldThrow<ArgumentException>().ParamName.ShouldBe("zipArchive");
                     }
                 }
             }
@@ -48,7 +48,7 @@ namespace KS.Fiks.ASiC_E.Test.Model
                     using (var readArchive = new ZipArchive(zipInStream, ZipArchiveMode.Read))
                     {
                         Action createAction = () => new AsiceReadModel(readArchive);
-                        createAction.Should().Throw<ArgumentException>().And.ParamName.Should().Be("zipArchive");
+                        createAction.ShouldThrow<ArgumentException>().ParamName.ShouldBe("zipArchive");
                     }
                 }
             }
@@ -73,9 +73,9 @@ namespace KS.Fiks.ASiC_E.Test.Model
                     using (var readArchive = new ZipArchive(zipInStream, ZipArchiveMode.Read))
                     {
                         var asiceArchive = new AsiceReadModel(readArchive);
-                        asiceArchive.Should().NotBeNull();
-                        asiceArchive.Entries.Count().Should().Be(0);
-                        asiceArchive.CadesManifest.Should().BeNull();
+                        asiceArchive.ShouldNotBeNull();
+                        asiceArchive.Entries.Count().ShouldBe(0);
+                        asiceArchive.CadesManifest.ShouldBeNull();
                     }
                 }
             }
@@ -89,19 +89,19 @@ namespace KS.Fiks.ASiC_E.Test.Model
                 using (var zip = new ZipArchive(asicStream, ZipArchiveMode.Read))
                 using (var asice = new AsiceReadModel(zip))
                 {
-                    asice.CadesManifest.Should().NotBeNull();
-                    asice.Signatures.Should().NotBeNull();
+                    asice.CadesManifest.ShouldNotBeNull();
+                    asice.Signatures.ShouldNotBeNull();
                     foreach (var asiceReadEntry in asice.Entries)
                     {
                         using (var entryStream = asiceReadEntry.OpenStream())
                         using (var bufferStream = new MemoryStream())
                         {
                             entryStream.CopyTo(bufferStream);
-                            bufferStream.Position.Should().BeGreaterThan(0);
+                            bufferStream.Position.ShouldBeGreaterThan(0);
                         }
                     }
 
-                    asice.DigestVerifier.Verification().AllValid.Should().BeTrue();
+                    asice.DigestVerifier.Verification().AllValid.ShouldBeTrue();
                 }
             }
         }
@@ -119,7 +119,7 @@ namespace KS.Fiks.ASiC_E.Test.Model
                 using (var asiceBuilder = AsiceBuilder.Create(outputStream, MessageDigestAlgorithm.SHA256, signingCertificates))
                 {
                     asiceBuilder.AddFile(textFileStream, contentFile, MimeType.ForString("text/plain"));
-                    asiceBuilder.Build().Should().NotBeNull();
+                    asiceBuilder.Build().ShouldNotBeNull();
                 }
 
                 using (var readStream = new MemoryStream(outputStream.ToArray()))
@@ -127,27 +127,27 @@ namespace KS.Fiks.ASiC_E.Test.Model
                 {
                     var asicePackage = new AsiceReadModel(zip);
                     var entries = asicePackage.Entries;
-                    entries.Count().Should().Be(1);
+                    entries.Count().ShouldBe(1);
                     var cadesManifest = asicePackage.CadesManifest;
-                    cadesManifest.Should().NotBeNull();
+                    cadesManifest.ShouldNotBeNull();
 
-                    cadesManifest.Digests.Count.Should().Be(1);
-                    asicePackage.DigestVerifier.Should().NotBeNull();
-                    cadesManifest.SignatureFileName.Should().NotBeNull();
-                    asicePackage.Signatures.Should().NotBeNull();
-                    asicePackage.Signatures.Containers.Count().Should().Be(1);
+                    cadesManifest.Digests.Count.ShouldBe(1);
+                    asicePackage.DigestVerifier.ShouldNotBeNull();
+                    cadesManifest.SignatureFileName.ShouldNotBeNull();
+                    asicePackage.Signatures.ShouldNotBeNull();
+                    asicePackage.Signatures.Containers.Count().ShouldBe(1);
 
                     var firstEntry = entries.First();
                     using (var entryStream = firstEntry.OpenStream())
                     using (var memoryStream = new MemoryStream())
                     {
                         entryStream.CopyTo(memoryStream);
-                        Encoding.UTF8.GetString(memoryStream.ToArray()).Should().Be(content);
+                        Encoding.UTF8.GetString(memoryStream.ToArray()).ShouldBe(content);
                     }
 
                     var verificationResult = asicePackage.DigestVerifier.Verification();
-                    verificationResult.Should().NotBeNull();
-                    verificationResult.AllValid.Should().BeTrue();
+                    verificationResult.ShouldNotBeNull();
+                    verificationResult.AllValid.ShouldBeTrue();
                 }
             }
         }

--- a/KS.Fiks.ASiC-E.Test/Model/CadesManifestTest.cs
+++ b/KS.Fiks.ASiC-E.Test/Model/CadesManifestTest.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using FluentAssertions;
 using KS.Fiks.ASiC_E.Model;
 using KS.Fiks.ASiC_E.Xsd;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.ASiC_E.Test.Model
@@ -15,7 +15,7 @@ namespace KS.Fiks.ASiC_E.Test.Model
         public void ProvideNull()
         {
             Action creator = () => new CadesManifest(null);
-            creator.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("asiCManifestType");
+            creator.ShouldThrow<ArgumentNullException>().ParamName.ShouldBe("asiCManifestType");
         }
 
         [Fact(DisplayName = "Instantiate using a quite empty manifest")]
@@ -23,11 +23,11 @@ namespace KS.Fiks.ASiC_E.Test.Model
         {
             var manifestType = new ASiCManifestType();
             var cadesManifest = new CadesManifest(manifestType);
-            cadesManifest.Should().NotBeNull();
-            cadesManifest.Spec.Should().Be(ManifestSpec.Cades);
-            cadesManifest.Digests.Should().BeNull();
-            cadesManifest.SignatureFileName.Should().BeNull();
-            cadesManifest.SignatureFileRef.Should().BeNull();
+            cadesManifest.ShouldNotBeNull();
+            cadesManifest.Spec.ShouldBe(ManifestSpec.Cades);
+            cadesManifest.Digests.ShouldBeNull();
+            cadesManifest.SignatureFileName.ShouldBeNull();
+            cadesManifest.SignatureFileRef.ShouldBeNull();
         }
 
         [Fact(DisplayName = "Instantiate with data objects")]
@@ -53,12 +53,12 @@ namespace KS.Fiks.ASiC_E.Test.Model
                 }
             };
             var cadesManifest = new CadesManifest(manifestType);
-            cadesManifest.Should().NotBeNull();
+            cadesManifest.ShouldNotBeNull();
             var digests = cadesManifest.Digests;
-            digests.Should().NotBeNull();
-            digests.Count.Should().Be(1);
-            digests.First().Value.MessageDigestAlgorithm.Should().BeEquivalentTo(digestAlgorithm);
-            cadesManifest.SignatureFileRef.Should().BeNull();
+            digests.ShouldNotBeNull();
+            digests.Count.ShouldBe(1);
+            digests.First().Value.MessageDigestAlgorithm.ShouldBeEquivalentTo(digestAlgorithm);
+            cadesManifest.SignatureFileRef.ShouldBeNull();
         }
 
         [Fact(DisplayName = "Instantiate with signature ref")]
@@ -74,12 +74,12 @@ namespace KS.Fiks.ASiC_E.Test.Model
                 }
             };
             var cadesManifest = new CadesManifest(manifestType);
-            cadesManifest.Should().NotBeNull();
-            cadesManifest.SignatureFileName.Should().NotBeNull();
-            cadesManifest.SignatureFileName.Should().Be(SignatureFileName);
-            cadesManifest.SignatureFileRef.Should().NotBeNull();
-            cadesManifest.SignatureFileRef.FileName.Should().Be(SignatureFileName);
-            cadesManifest.SignatureFileRef.MimeType.Should().Be(AsiceConstants.MimeTypeCadesSignature);
+            cadesManifest.ShouldNotBeNull();
+            cadesManifest.SignatureFileName.ShouldNotBeNull();
+            cadesManifest.SignatureFileName.ShouldBe(SignatureFileName);
+            cadesManifest.SignatureFileRef.ShouldNotBeNull();
+            cadesManifest.SignatureFileRef.FileName.ShouldBe(SignatureFileName);
+            cadesManifest.SignatureFileRef.MimeType.ShouldBe(AsiceConstants.MimeTypeCadesSignature);
         }
     }
 }

--- a/KS.Fiks.ASiC-E.Test/Model/DeclaredDigestFileTest.cs
+++ b/KS.Fiks.ASiC-E.Test/Model/DeclaredDigestFileTest.cs
@@ -1,5 +1,5 @@
-using FluentAssertions;
 using KS.Fiks.ASiC_E.Model;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.ASiC_E.Test.Model
@@ -14,7 +14,7 @@ namespace KS.Fiks.ASiC_E.Test.Model
         {
             var calculatedDigest = new byte[] { 0, 1, 0, 1 };
             var digest = new DeclaredDigestFile(calculatedDigest, MessageDigestAlgorithm.SHA256, FileName, MimeType);
-            digest.Verify(new DeclaredDigestFile(calculatedDigest, digest.MessageDigestAlgorithm, FileName, MimeType)).Should().BeTrue();
+            digest.Verify(new DeclaredDigestFile(calculatedDigest, digest.MessageDigestAlgorithm, FileName, MimeType)).ShouldBeTrue();
         }
 
         [Fact(DisplayName = "Verify equal digest but not algorithm")]
@@ -22,15 +22,14 @@ namespace KS.Fiks.ASiC_E.Test.Model
         {
             var calculatedDigest = new byte[] { 0, 1, 0, 1 };
             var digest = new DeclaredDigestFile(calculatedDigest, MessageDigestAlgorithm.SHA256, FileName, MimeType);
-            digest.Verify(new DeclaredDigestFile(calculatedDigest, MessageDigestAlgorithm.SHA384, FileName, MimeType)).Should().BeFalse();
+            digest.Verify(new DeclaredDigestFile(calculatedDigest, MessageDigestAlgorithm.SHA384, FileName, MimeType)).ShouldBeFalse();
         }
 
         [Fact(DisplayName = "Verify different digest and equal algorithm")]
         public void VerifyEqualAlgorithmButDifferentDigest()
         {
             new DeclaredDigestFile(new byte[] { 0, 0, 0, 0 }, MessageDigestAlgorithm.SHA512, FileName, MimeType)
-                .Verify(new DeclaredDigestFile(new byte[] { 1, 1, 1, 1 }, MessageDigestAlgorithm.SHA512, FileName, MimeType)).Should()
-                .BeFalse();
+                .Verify(new DeclaredDigestFile(new byte[] { 1, 1, 1, 1 }, MessageDigestAlgorithm.SHA512, FileName, MimeType)).ShouldBeFalse();
         }
     }
 }

--- a/KS.Fiks.ASiC-E.Test/Model/MessageDigestAlgorithmFromUriTest.cs
+++ b/KS.Fiks.ASiC-E.Test/Model/MessageDigestAlgorithmFromUriTest.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using FluentAssertions;
 using KS.Fiks.ASiC_E.Model;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.ASiC_E.Test.Model
@@ -13,7 +11,7 @@ namespace KS.Fiks.ASiC_E.Test.Model
         [ClassData(typeof(UriAndAlgorithmCollection))]
         public void TestFromUri(Uri uri, MessageDigestAlgorithm expectedAlgorithm)
         {
-            MessageDigestAlgorithm.FromUri(uri).Should().Be(expectedAlgorithm);
+            MessageDigestAlgorithm.FromUri(uri).ShouldBe(expectedAlgorithm);
         }
     }
 }

--- a/KS.Fiks.ASiC-E.Test/Model/MessageDigestAlgorithmTest.cs
+++ b/KS.Fiks.ASiC-E.Test/Model/MessageDigestAlgorithmTest.cs
@@ -1,8 +1,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-using FluentAssertions;
 using KS.Fiks.ASiC_E.Model;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.ASiC_E.Test.Model
@@ -22,27 +21,27 @@ namespace KS.Fiks.ASiC_E.Test.Model
         [MemberData(nameof(Algorithms))]
         public void TestStaticProperties(MessageDigestAlgorithm messageDigestAlgorithm)
         {
-            messageDigestAlgorithm.Name.Should().NotBeNull();
-            messageDigestAlgorithm.Uri.Should().NotBeNull();
-            messageDigestAlgorithm.Digest.Should().NotBeNull();
+            messageDigestAlgorithm.Name.ShouldNotBeNull();
+            messageDigestAlgorithm.Uri.ShouldNotBeNull();
+            messageDigestAlgorithm.Digest.ShouldNotBeNull();
         }
 
         [Fact(DisplayName = "Test that the static field UriSHA256 is initialized")]
         public void Uri256()
         {
-            MessageDigestAlgorithm.UriSHA256XmlEnc.Should().NotBeNull();
+            MessageDigestAlgorithm.UriSHA256XmlEnc.ShouldNotBeNull();
         }
 
         [Fact(DisplayName = "Test that the static field UriSHA384 is initialized")]
         public void Uri384()
         {
-            MessageDigestAlgorithm.UriSHA384XmlEnc.Should().NotBeNull();
+            MessageDigestAlgorithm.UriSHA384XmlEnc.ShouldNotBeNull();
         }
 
         [Fact(DisplayName = "Test that the static field UriSHA512 is initialized")]
         public void Uri512()
         {
-            MessageDigestAlgorithm.UriSHA512XmlEnc.Should().NotBeNull();
+            MessageDigestAlgorithm.UriSHA512XmlEnc.ShouldNotBeNull();
         }
     }
 }

--- a/KS.Fiks.ASiC-E.Test/Sign/SignatureVerifierTest.cs
+++ b/KS.Fiks.ASiC-E.Test/Sign/SignatureVerifierTest.cs
@@ -1,5 +1,5 @@
-using FluentAssertions;
 using KS.Fiks.ASiC_E.Sign;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.ASiC_E.Test.Sign
@@ -13,7 +13,7 @@ namespace KS.Fiks.ASiC_E.Test.Sign
             var signedData = TestdataLoader.ReadFromResource("signedData.xml");
             var signatureVerifier = new SignatureVerifier();
             var certificate = signatureVerifier.Validate(signedData, signature);
-            certificate.Should().NotBeNull();
+            certificate.ShouldNotBeNull();
         }
     }
 }

--- a/KS.Fiks.ASiC-E/KS.Fiks.ASiC-E.csproj
+++ b/KS.Fiks.ASiC-E/KS.Fiks.ASiC-E.csproj
@@ -29,13 +29,13 @@
   </PropertyGroup>        
 
   <ItemGroup>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.0" />
     <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-    <PackageReference Include="MimeMapping" Version="3.0.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="MimeMapping" Version="3.1.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="9.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
**Dette er gjort:**
Erstattet Fluent Assertions med Shouldly og oppdatert tester.

Oppdatert følgende dependencies:
- Bumps [BouncyCastle.Cryptography](https://github.com/bcgit/bc-csharp) from 2.4.0 to 2.5.0.
- Bumps [MimeMapping](https://github.com/zone117x/MimeMapping) from 3.0.1 to 3.1.0.
- Bumps [xunit.analyzers](https://github.com/xunit/xunit.analyzers) from 1.17.0 to 1.19.0.
- Bumps [xunit.runner.visualstudio](https://github.com/xunit/visualstudio.xunit) from 2.8.2 to 3.0.1.
- Bumps Microsoft.Extensions.Logging from 8.0.1 to 9.0.1
- Bumps [System.Collections.Immutable](https://github.com/dotnet/runtime) from 8.0.0 to 9.0.1.