### PR TITLE
Feature/add xades signing

### DIFF
--- a/KS.Fiks.ASiC-E.Test/AsiceBuilderCustomManifestTests.cs
+++ b/KS.Fiks.ASiC-E.Test/AsiceBuilderCustomManifestTests.cs
@@ -1,0 +1,202 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+using KS.Fiks.ASiC_E.Manifest;
+using KS.Fiks.ASiC_E.Model;
+using Shouldly;
+using Xunit;
+
+namespace KS.Fiks.ASiC_E.Test;
+
+public class AsiceBuilderCustomManifestTests
+{
+    private static readonly XNamespace _ns = XNamespace.Get(
+        "http://example.invalid/dummy-manifest-namespace");
+
+    [Fact]
+    public void CreateAsicWithCustomManifestWithXades()
+    {
+        CreateAsicWithCustomManifest(ManifestSpec.Xades);
+    }
+
+    [Fact]
+    public void CreateAsicWithCustomManifestWithCades()
+    {
+        CreateAsicWithCustomManifest(ManifestSpec.Cades);
+    }
+
+    private void CreateAsicWithCustomManifest(ManifestSpec spec)
+    {
+        var certHolder = TestdataLoader.ReadCertificatesForTest();
+
+        Func<IManifestCreator> makeManifestCreator =
+            () => new CustomManifestFormat(spec);
+
+        using var zipStream = new MemoryStream();
+
+        using (var asiceBuilder = AsiceBuilder.Create(
+            zipStream,
+            MessageDigestAlgorithm.SHA256,
+            spec,
+            certHolder,
+            makeManifestCreator))
+        {
+            asiceBuilder.ShouldNotBeNull();
+
+            // We add three files: One introduction file, and two attachments:
+            asiceBuilder.AddFile(
+                new MemoryStream(
+                    Encoding.UTF8.GetBytes(
+                        "Please find the requested documents attached.")),
+                "intro.txt");
+
+            using (var attachment1= File.OpenRead("small.pdf"))
+            {
+                asiceBuilder.AddFile(attachment1, "attachment1.pdf");
+            }
+
+            using (var attachment2 = File.OpenRead("small.pdf"))
+            {
+                asiceBuilder.AddFile(attachment2, "attachment2.odt");
+            }
+
+            var asiceArchive = asiceBuilder.Build();
+            asiceArchive.ShouldNotBeNull();
+        }
+
+        byte[] zippedBytes = zipStream.ToArray();
+        zippedBytes.Length.ShouldBeGreaterThan(0);
+
+        bool foundUnknownEntry = false;
+        bool foundManifest = false;
+        using (var zipStream_ = new MemoryStream(zippedBytes))
+        using (var zipArchive = new ZipArchive(zipStream_, ZipArchiveMode.Read))
+        {
+            zipArchive.Entries.Count.ShouldBe(6);
+
+            var invCult = StringComparison.InvariantCulture;
+
+            Func<string, bool> findCadesSignature = (filepath) =>
+                filepath.StartsWith("META-INF/signature-", invCult) &&
+                filepath.EndsWith(".p7s", invCult);
+
+            Func<string, bool> findXadesSignature = (filepath) =>
+                filepath == "META-INF/signatures.xml";
+
+            string expectedManifest = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <manifest xmlns="http://example.invalid/dummy-manifest-namespace">
+              <maindocument href="intro.txt" mime="text/plain" />
+              <attachment href="attachment1.pdf" mime="application/pdf" />
+              <attachment href="attachment2.odt" mime="application/vnd.oasis.opendocument.text" />
+            </manifest>
+            """;
+
+            foreach (var entry in zipArchive.Entries)
+            {
+                var filepath = entry.FullName;
+                switch (filepath)
+                {
+                    case "mimetype": break;
+                    case "intro.txt": break;
+                    case "attachment1.pdf": break;
+                    case "attachment2.odt": break;
+                    case "META-INF/customManifest.xml":
+                        using (var manifestStream = entry.Open())
+                        using (var copyStream = new MemoryStream())
+                        {
+                            foundManifest = true;
+                            manifestStream.CopyTo(copyStream);
+                            var manifestBytes = copyStream.ToArray();
+                            manifestBytes.Length.ShouldBeGreaterThan(0);
+                            var manifestContent = Encoding.UTF8.GetString(manifestBytes);
+                            manifestContent.ShouldBe(
+                                expectedManifest,
+                                StringCompareShould.IgnoreLineEndings);
+                        }
+
+                        break;
+                    default:
+                        bool foundSignature = (spec == ManifestSpec.Cades
+                            ? findCadesSignature
+                            : findXadesSignature)(filepath);
+
+                        if (!foundSignature)
+                        {
+                            foundUnknownEntry = true;
+                        }
+
+                        break;
+                }
+            }
+        }
+
+        foundUnknownEntry.ShouldBeFalse();
+        foundManifest.ShouldBeTrue();
+    }
+
+    private class CustomManifestFormat : IManifestCreator
+    {
+        private readonly ManifestSpec _spec;
+
+        public CustomManifestFormat(ManifestSpec spec)
+        {
+            _spec = spec;
+        }
+
+        public ManifestContainer CreateManifest(
+            IEnumerable<AsicePackageEntry> entries,
+            SignatureFileRef signatureFileRef)
+        {
+            var settings = new XmlWriterSettings
+            {
+                Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                Indent = true,
+            };
+
+            AsicePackageEntry[] entriesArray = entries?.ToArray();
+            AsicePackageEntry mainEntry = entriesArray[0];
+            AsicePackageEntry[] attachments = entriesArray[1..];
+
+            XDocument doc = new XDocument(
+                new XElement(
+                    _ns + "manifest",
+                    new XAttribute("xmlns", _ns),
+                    MakePayloadElement(true, mainEntry),
+                    attachments.Select(
+                        attachment => MakePayloadElement(false, attachment))));
+
+            using var memStream = new MemoryStream();
+
+            using (var writer = XmlWriter.Create(memStream, settings))
+            {
+                doc.Save(writer);
+            }
+
+            byte[] bytes = memStream.ToArray();
+
+            return new ManifestContainer(
+                fileName: "META-INF/customManifest.xml",
+                data: bytes,
+                signatureFileRef: signatureFileRef,
+                manifestSpec: _spec);
+        }
+
+        private XElement MakePayloadElement(
+            bool isMainDocument,
+            AsicePackageEntry attachment)
+        {
+            string elemName = isMainDocument ? "maindocument" : "attachment";
+
+            return new XElement(
+                _ns + elemName,
+                new XAttribute("href", attachment.FileName),
+                new XAttribute("mime", attachment.Type.ToString()));
+        }
+    }
+}

--- a/KS.Fiks.ASiC-E.Test/AsiceBuilderTest.cs
+++ b/KS.Fiks.ASiC-E.Test/AsiceBuilderTest.cs
@@ -17,7 +17,11 @@ public class AsiceBuilderTest
         var zipStream = new Mock<Stream>();
         var certificate = new Mock<ICertificateHolder>();
         Action createFunction = () =>
-            AsiceBuilder.Create(zipStream.Object, MessageDigestAlgorithm.SHA512, certificate.Object);
+            AsiceBuilder.Create(
+                zipStream.Object,
+                MessageDigestAlgorithm.SHA512,
+                ManifestSpec.Cades,
+                certificate.Object);
         createFunction.ShouldThrow<ArgumentException>();
         zipStream.VerifyGet(s => s.CanWrite);
         zipStream.VerifyNoOtherCalls();
@@ -32,8 +36,11 @@ public class AsiceBuilderTest
         using (var zipStream = new MemoryStream())
         using (var fileStream = File.OpenRead("small.pdf"))
         {
-            using (var asiceBuilder =
-                   AsiceBuilder.Create(zipStream, MessageDigestAlgorithm.SHA256, signingCertificates))
+            using (var asiceBuilder = AsiceBuilder.Create(
+                zipStream,
+                MessageDigestAlgorithm.SHA256,
+                ManifestSpec.Cades,
+                signingCertificates))
             {
                 asiceBuilder.ShouldNotBeNull();
 
@@ -67,8 +74,11 @@ public class AsiceBuilderTest
         using (var zipStream = new MemoryStream())
         using (var fileStream = File.OpenRead("small.pdf"))
         {
-            using (var asiceBuilder =
-                AsiceBuilder.Create(zipStream, MessageDigestAlgorithm.SHA256, signingCertificates))
+            using (var asiceBuilder = AsiceBuilder.Create(
+                zipStream,
+                MessageDigestAlgorithm.SHA256,
+                ManifestSpec.Cades,
+                signingCertificates))
             {
                 asiceBuilder.ShouldNotBeNull();
 

--- a/KS.Fiks.ASiC-E.Test/Model/AsiceArchiveTest.cs
+++ b/KS.Fiks.ASiC-E.Test/Model/AsiceArchiveTest.cs
@@ -6,6 +6,7 @@ using System.Text;
 using KS.Fiks.ASiC_E.Crypto;
 using KS.Fiks.ASiC_E.Manifest;
 using KS.Fiks.ASiC_E.Model;
+using KS.Fiks.ASiC_E.Sign;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
@@ -49,12 +50,15 @@ public class AsiceArchiveTest
         byte[] zippedData;
         using (var zippedOutStream = new MemoryStream())
         {
-            var cadesManifestCreator = certHolder == null
-                ? CadesManifestCreator.CreateWithoutSignatureFile()
-                : CadesManifestCreator.CreateWithSignatureFile();
+            // signatureFileRefCreator should be null if and only if certHolder is null:
+            var signatureFileRefCreator = certHolder == null
+                ? null
+                : new CadesSignature();
+            var cadesManifestCreator = new CadesManifestCreator();
             using (var archive = new AsiceArchive(
                        zippedOutStream,
                        cadesManifestCreator,
+                       signatureFileRefCreator,
                        certHolder))
             using (var fileStream = File.OpenRead(FileNameTestPdf))
             {
@@ -133,9 +137,12 @@ public class AsiceArchiveTest
         public void CreateArchiveWithReuseOfZippedOutStream()
         {
             using var zippedOutStream = new MemoryStream();
+            var cadesManifestCreator = new CadesManifestCreator();
+            var signatureFileRefCreator = new CadesSignature();
             using (var archive = new AsiceArchive(
                        zippedOutStream,
-                       CadesManifestCreator.CreateWithSignatureFile(),
+                       cadesManifestCreator,
+                       signatureFileRefCreator,
                        TestdataLoader.ReadCertificatesForTest()))
             using (var fileStream = File.OpenRead(FileNameTestPdf))
             {

--- a/KS.Fiks.ASiC-E.Test/Model/AsiceArchiveTest.cs
+++ b/KS.Fiks.ASiC-E.Test/Model/AsiceArchiveTest.cs
@@ -50,16 +50,21 @@ public class AsiceArchiveTest
         byte[] zippedData;
         using (var zippedOutStream = new MemoryStream())
         {
-            // signatureFileRefCreator should be null if and only if certHolder is null:
+            // signatureFileRefCreator and signatureCreator should both be
+            // null if and only if certHolder is null:
             var signatureFileRefCreator = certHolder == null
                 ? null
                 : new CadesSignature();
+            var signatureCreator = certHolder == null
+                ? null
+                : SignatureCreator.Create(certHolder);
             var cadesManifestCreator = new CadesManifestCreator();
             using (var archive = new AsiceArchive(
-                       zippedOutStream,
-                       cadesManifestCreator,
-                       signatureFileRefCreator,
-                       certHolder))
+                zippedOutStream,
+                cadesManifestCreator,
+                signatureFileRefCreator,
+                signatureCreator,
+                certHolder))
             using (var fileStream = File.OpenRead(FileNameTestPdf))
             {
                 archive.AddEntry(
@@ -139,11 +144,14 @@ public class AsiceArchiveTest
             using var zippedOutStream = new MemoryStream();
             var cadesManifestCreator = new CadesManifestCreator();
             var signatureFileRefCreator = new CadesSignature();
+            var certHolder = TestdataLoader.ReadCertificatesForTest();
+            var signatureCreator = SignatureCreator.Create(certHolder);
             using (var archive = new AsiceArchive(
-                       zippedOutStream,
-                       cadesManifestCreator,
-                       signatureFileRefCreator,
-                       TestdataLoader.ReadCertificatesForTest()))
+                zippedOutStream,
+                cadesManifestCreator,
+                signatureFileRefCreator,
+                signatureCreator,
+                certHolder))
             using (var fileStream = File.OpenRead(FileNameTestPdf))
             {
                 archive.AddEntry(

--- a/KS.Fiks.ASiC-E.Test/Model/AsiceArchiveTest.cs
+++ b/KS.Fiks.ASiC-E.Test/Model/AsiceArchiveTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -67,6 +68,9 @@ public class AsiceArchiveTest
 
     private void TestArchive(ICertificateHolder certHolder, ManifestSpec spec)
     {
+        var signingTimeStamp = DateTime.Parse(
+            "2025-07-27T15:53:18",
+            CultureInfo.InvariantCulture);
         byte[] zippedData;
         using (var zippedOutStream = new MemoryStream())
         {
@@ -82,7 +86,7 @@ public class AsiceArchiveTest
                 ? null
                 : (spec == ManifestSpec.Cades
                     ? SignatureCreator.Create(certHolder)
-                    : XadesSignatureCreator.Create(certHolder));
+                    : XadesSignatureCreator.Create(certHolder, () => signingTimeStamp));
 
             // Perhaps not realistic to use a CAdES manifest with both CAdES
             // and XAdES signatures, but in the absence of a distinct XAdES

--- a/KS.Fiks.ASiC-E.Test/Model/AsiceArchiveTest.cs
+++ b/KS.Fiks.ASiC-E.Test/Model/AsiceArchiveTest.cs
@@ -63,8 +63,7 @@ public class AsiceArchiveTest
                 zippedOutStream,
                 cadesManifestCreator,
                 signatureFileRefCreator,
-                signatureCreator,
-                certHolder))
+                signatureCreator))
             using (var fileStream = File.OpenRead(FileNameTestPdf))
             {
                 archive.AddEntry(
@@ -150,8 +149,7 @@ public class AsiceArchiveTest
                 zippedOutStream,
                 cadesManifestCreator,
                 signatureFileRefCreator,
-                signatureCreator,
-                certHolder))
+                signatureCreator))
             using (var fileStream = File.OpenRead(FileNameTestPdf))
             {
                 archive.AddEntry(

--- a/KS.Fiks.ASiC-E.Test/Model/AsiceReadModelTest.cs
+++ b/KS.Fiks.ASiC-E.Test/Model/AsiceReadModelTest.cs
@@ -116,7 +116,11 @@ namespace KS.Fiks.ASiC_E.Test.Model
             using (var outputStream = new MemoryStream())
             {
                 using (var textFileStream = new MemoryStream(Encoding.UTF8.GetBytes(content)))
-                using (var asiceBuilder = AsiceBuilder.Create(outputStream, MessageDigestAlgorithm.SHA256, signingCertificates))
+                using (var asiceBuilder = AsiceBuilder.Create(
+                    outputStream,
+                    MessageDigestAlgorithm.SHA256,
+                    ManifestSpec.Cades,
+                    signingCertificates))
                 {
                     asiceBuilder.AddFile(textFileStream, contentFile, MimeType.ForString("text/plain"));
                     asiceBuilder.Build().ShouldNotBeNull();

--- a/KS.Fiks.ASiC-E/AsiceBuilder.cs
+++ b/KS.Fiks.ASiC-E/AsiceBuilder.cs
@@ -15,6 +15,9 @@ public sealed class AsiceBuilder : IAsiceBuilder<AsiceArchive>
         ManifestSpec spec)
     => spec switch
         {
+            // TODO: A standard XAdES manifest has not been implemented
+            // yet, since the initial usecase for XAdES required a
+            // custom manifest format
             ManifestSpec.Cades => new CadesManifestCreator(),
             _ => throw new ArgumentException(
                 "Only CAdES-style manifests are currently supported."),
@@ -28,6 +31,7 @@ public sealed class AsiceBuilder : IAsiceBuilder<AsiceArchive>
         : spec switch
         {
             ManifestSpec.Cades => new CadesSignature(),
+            ManifestSpec.Xades => new XadesSignature(),
             _ => throw new ArgumentException(
                 "Only CAdES-style manifests are currently supported."),
         };
@@ -40,6 +44,7 @@ public sealed class AsiceBuilder : IAsiceBuilder<AsiceArchive>
         : spec switch
         {
             ManifestSpec.Cades => SignatureCreator.Create(certificateHolder),
+            ManifestSpec.Xades => XadesSignatureCreator.Create(certificateHolder),
             _ => throw new ArgumentException(
                 "Only CAdES-style manifests are currently supported."),
         };

--- a/KS.Fiks.ASiC-E/AsiceBuilder.cs
+++ b/KS.Fiks.ASiC-E/AsiceBuilder.cs
@@ -11,6 +11,39 @@ public sealed class AsiceBuilder : IAsiceBuilder<AsiceArchive>
 {
     private readonly AsiceArchive _asiceArchive;
 
+    private static IManifestCreator FindManifestCreator(
+        ManifestSpec spec)
+    => spec switch
+        {
+            ManifestSpec.Cades => new CadesManifestCreator(),
+            _ => throw new ArgumentException(
+                "Only CAdES-style manifests are currently supported."),
+        };
+
+    private static ISignatureFileRefCreator FindSignatureFileRefCreator(
+        ManifestSpec spec,
+        ICertificateHolder certificateHolder)
+    => (certificateHolder == null)
+        ? null
+        : spec switch
+        {
+            ManifestSpec.Cades => new CadesSignature(),
+            _ => throw new ArgumentException(
+                "Only CAdES-style manifests are currently supported."),
+        };
+
+    private static ISignatureCreator FindSignatureCreator(
+      ManifestSpec spec,
+      ICertificateHolder certificateHolder)
+    => (certificateHolder == null)
+        ? null
+        : spec switch
+        {
+            ManifestSpec.Cades => SignatureCreator.Create(certificateHolder),
+            _ => throw new ArgumentException(
+                "Only CAdES-style manifests are currently supported."),
+        };
+
     private AsiceBuilder(AsiceArchive asiceArchive)
     {
         _asiceArchive = asiceArchive;
@@ -24,9 +57,32 @@ public sealed class AsiceBuilder : IAsiceBuilder<AsiceArchive>
     /// <param name="signCertificate">A private/public keypair to use for signing. May be null</param>
     /// <returns>A builder that may be used to construct a ASiC-E package</returns>
     /// <exception cref="ArgumentException">If the provided stream is not writable</exception>
+    [Obsolete("This overload is kept for backwards compatibility. Move over to the new Create() that exposes a ManifestSpec parameter.")]
     public static AsiceBuilder Create(
         Stream stream,
         MessageDigestAlgorithm messageDigestAlgorithm,
+        ICertificateHolder signCertificate)
+    {
+        return Create(
+            stream,
+            messageDigestAlgorithm,
+            ManifestSpec.Cades,
+            signCertificate);
+    }
+
+    /// <summary>
+    /// Create builder
+    /// </summary>
+    /// <param name="stream">The stream where the ASiC-E data will be written. Can not be null and must be writable</param>
+    /// <param name="messageDigestAlgorithm">The digest algorithm to use. Not nullable</param>
+    /// <param name="manifestSpec">An enum saying the type of signature to add</param>
+    /// <param name="signCertificate">A private/public keypair to use for signing. May be null</param>
+    /// <returns>A builder that may be used to construct a ASiC-E package</returns>
+    /// <exception cref="ArgumentException">If the provided stream is not writable</exception>
+    public static AsiceBuilder Create(
+        Stream stream,
+        MessageDigestAlgorithm messageDigestAlgorithm,
+        ManifestSpec manifestSpec,
         ICertificateHolder signCertificate)
     {
         var outStream = stream ?? throw new ArgumentNullException(nameof(stream));
@@ -36,15 +92,15 @@ public sealed class AsiceBuilder : IAsiceBuilder<AsiceArchive>
             throw new ArgumentException("The provided Stream must be writable", nameof(stream));
         }
 
-        var sigFileRefCreator = signCertificate == null
-            ? null
-            : new CadesSignature();
-        var cadesManifestCreator = new CadesManifestCreator();
+        var sigCreator = FindSignatureCreator(manifestSpec, signCertificate);
+        var sigFileRefCreator = FindSignatureFileRefCreator(manifestSpec, signCertificate);
+        var manifestCreator = FindManifestCreator(manifestSpec);
 
         return new AsiceBuilder(new AsiceArchive(
             outStream,
-            cadesManifestCreator,
+            manifestCreator,
             sigFileRefCreator,
+            sigCreator,
             signCertificate));
     }
 

--- a/KS.Fiks.ASiC-E/AsiceBuilder.cs
+++ b/KS.Fiks.ASiC-E/AsiceBuilder.cs
@@ -113,8 +113,7 @@ public sealed class AsiceBuilder : IAsiceBuilder<AsiceArchive>
             outStream,
             manifestCreator,
             sigFileRefCreator,
-            sigCreator,
-            signCertificate));
+            sigCreator));
     }
 
     public AsiceArchive Build()

--- a/KS.Fiks.ASiC-E/AsiceBuilder.cs
+++ b/KS.Fiks.ASiC-E/AsiceBuilder.cs
@@ -3,6 +3,7 @@ using System.IO;
 using KS.Fiks.ASiC_E.Crypto;
 using KS.Fiks.ASiC_E.Manifest;
 using KS.Fiks.ASiC_E.Model;
+using KS.Fiks.ASiC_E.Sign;
 
 namespace KS.Fiks.ASiC_E;
 
@@ -35,10 +36,16 @@ public sealed class AsiceBuilder : IAsiceBuilder<AsiceArchive>
             throw new ArgumentException("The provided Stream must be writable", nameof(stream));
         }
 
-        var cadesManifestCreator = signCertificate == null
-            ? CadesManifestCreator.CreateWithoutSignatureFile()
-            : CadesManifestCreator.CreateWithSignatureFile();
-        return new AsiceBuilder(new AsiceArchive(outStream, cadesManifestCreator, signCertificate));
+        var sigFileRefCreator = signCertificate == null
+            ? null
+            : new CadesSignature();
+        var cadesManifestCreator = new CadesManifestCreator();
+
+        return new AsiceBuilder(new AsiceArchive(
+            outStream,
+            cadesManifestCreator,
+            sigFileRefCreator,
+            signCertificate));
     }
 
     public AsiceArchive Build()

--- a/KS.Fiks.ASiC-E/Crypto/SystemX509CertificateHolder.cs
+++ b/KS.Fiks.ASiC-E/Crypto/SystemX509CertificateHolder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Security;
@@ -19,6 +20,15 @@ namespace KS.Fiks.ASiC_E.Crypto
         public X509Certificate GetPublicCertificate()
         {
             return Cert;
+        }
+
+        public IReadOnlyList<X509Certificate> GetCertificateChain()
+        {
+            // TODO: Add support for certificate chains in this implementation
+            // of ICertificateHolder as well, assuming this implementation is
+            // actually used (it doesn't seem to be, but is public, so maybe
+            // some client uses it).
+            return Array.Empty<X509Certificate>();
         }
 
         private X509Certificate Cert { get; }

--- a/KS.Fiks.ASiC-E/KS.Fiks.ASiC-E.csproj
+++ b/KS.Fiks.ASiC-E/KS.Fiks.ASiC-E.csproj
@@ -40,6 +40,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/KS.Fiks.ASiC-E/Manifest/AbstractManifestCreator.cs
+++ b/KS.Fiks.ASiC-E/Manifest/AbstractManifestCreator.cs
@@ -6,7 +6,9 @@ namespace KS.Fiks.ASiC_E.Manifest
 {
     public abstract class AbstractManifestCreator : IManifestCreator
     {
-        public abstract ManifestContainer CreateManifest(IEnumerable<AsicePackageEntry> entries);
+        public abstract ManifestContainer CreateManifest(
+            IEnumerable<AsicePackageEntry> entries,
+            SignatureFileRef signatureFileRef);
 
         protected static SignatureFileRef CreateSignatureRef()
         {

--- a/KS.Fiks.ASiC-E/Manifest/CadesManifestCreator.cs
+++ b/KS.Fiks.ASiC-E/Manifest/CadesManifestCreator.cs
@@ -38,7 +38,7 @@ namespace KS.Fiks.ASiC_E.Manifest
             SignatureFileRef signatureFileRef = null;
             if (addSignatureFile)
             {
-                signatureFileRef = CadesSignature.CreateSignatureRef();
+                signatureFileRef = new CadesSignature().CreateSignatureRef();
                 manifest.SigReference = new SigReferenceType
                 {
                     MimeType = signatureFileRef.MimeType.ToString(), URI = signatureFileRef.FileName

--- a/KS.Fiks.ASiC-E/Manifest/CadesManifestCreator.cs
+++ b/KS.Fiks.ASiC-E/Manifest/CadesManifestCreator.cs
@@ -6,7 +6,6 @@ using System.Text;
 using System.Xml;
 using System.Xml.Serialization;
 using KS.Fiks.ASiC_E.Model;
-using KS.Fiks.ASiC_E.Sign;
 using KS.Fiks.ASiC_E.Xsd;
 
 namespace KS.Fiks.ASiC_E.Manifest
@@ -15,30 +14,14 @@ namespace KS.Fiks.ASiC_E.Manifest
     {
         private static readonly Encoding Encoding = Encoding.UTF8;
 
-        private readonly bool addSignatureFile;
-
-        private CadesManifestCreator(bool addSignatureFile)
-        {
-            this.addSignatureFile = addSignatureFile;
-        }
-
-        public static CadesManifestCreator CreateWithSignatureFile()
-        {
-            return new CadesManifestCreator(true);
-        }
-
-        public static CadesManifestCreator CreateWithoutSignatureFile()
-        {
-            return new CadesManifestCreator(false);
-        }
-
-        public ManifestContainer CreateManifest(IEnumerable<AsicePackageEntry> entries)
+        public ManifestContainer CreateManifest(
+            IEnumerable<AsicePackageEntry> entries,
+            SignatureFileRef signatureFileRef)
         {
             var manifest = new ASiCManifestType { DataObjectReference = entries.Select(ToDataObject).ToArray() };
-            SignatureFileRef signatureFileRef = null;
-            if (addSignatureFile)
+
+            if (signatureFileRef is not null)
             {
-                signatureFileRef = new CadesSignature().CreateSignatureRef();
                 manifest.SigReference = new SigReferenceType
                 {
                     MimeType = signatureFileRef.MimeType.ToString(), URI = signatureFileRef.FileName

--- a/KS.Fiks.ASiC-E/Manifest/IManifestCreator.cs
+++ b/KS.Fiks.ASiC-E/Manifest/IManifestCreator.cs
@@ -5,6 +5,21 @@ namespace KS.Fiks.ASiC_E.Manifest
 {
     public interface IManifestCreator
     {
+        /// <summary>
+        /// Creates a <see cref="ManifestContainer"/> with a finished, serialized
+        /// manifest file, containing information on the enumerated entries, and
+        /// optionally a reference to the signature file. The
+        /// <see cref="ManifestContainer"/> will have the provided filename
+        /// registered, which will determine the filename of the manifest
+        /// in the ASiC container's internal file tree structure.
+        /// </summary>
+        /// <param name="entries">The entries to list in the manifest.</param>
+        /// <param name="signatureFileRef">An object that holds information
+        /// about the signature file. If null, the signature reference
+        /// will be omitted from the serialized manifest and the
+        /// <see cref="ManifestContainer.SignatureFileRef"/> property
+        /// in the returned object will be null.</param>
+        /// <returns>A <see cref="ManifestContainer"/>.</returns>
         ManifestContainer CreateManifest(
             IEnumerable<AsicePackageEntry> entries,
             SignatureFileRef signatureFileRef);

--- a/KS.Fiks.ASiC-E/Manifest/IManifestCreator.cs
+++ b/KS.Fiks.ASiC-E/Manifest/IManifestCreator.cs
@@ -5,6 +5,8 @@ namespace KS.Fiks.ASiC_E.Manifest
 {
     public interface IManifestCreator
     {
-        ManifestContainer CreateManifest(IEnumerable<AsicePackageEntry> entries);
+        ManifestContainer CreateManifest(
+            IEnumerable<AsicePackageEntry> entries,
+            SignatureFileRef signatureFileRef);
     }
 }

--- a/KS.Fiks.ASiC-E/Model/AsiceArchive.cs
+++ b/KS.Fiks.ASiC-E/Model/AsiceArchive.cs
@@ -167,7 +167,7 @@ public class AsiceArchive : IDisposable
         if (manifest.ManifestSpec == ManifestSpec.Cades && signatureFileRef != null)
         {
             manifest.SignatureFileRef = signatureFileRef;
-            var signatureFile = SignatureCreator.Create(_signatureCertificate).CreateCadesSignatureFile(manifest);
+            var signatureFile = SignatureCreator.Create(_signatureCertificate).CreateSignatureFile(manifest, _entries);
             using var signatureStream = new MemoryStream(signatureFile.Data.ToArray());
             var entry = _zipArchive.CreateEntry(signatureFile.SignatureFileRef.FileName);
             using var zipEntryStream = entry.Open();

--- a/KS.Fiks.ASiC-E/Model/AsiceArchive.cs
+++ b/KS.Fiks.ASiC-E/Model/AsiceArchive.cs
@@ -19,6 +19,8 @@ public class AsiceArchive : IDisposable
 
     private readonly IManifestCreator _manifestCreator;
 
+    private readonly ISignatureCreator _signatureCreator;
+
     private readonly ISignatureFileRefCreator _signatureFileRefCreator;
 
     private readonly MessageDigestAlgorithm _messageDigestAlgorithm;
@@ -35,6 +37,7 @@ public class AsiceArchive : IDisposable
         ISignatureFileRefCreator signatureFileRefCreator,
         MessageDigestAlgorithm messageDigestAlgorithm,
         ICertificateHolder signatureCertificate,
+        ISignatureCreator signatureCreator,
         ILoggerFactory loggerFactory = null)
     {
         _zipArchive = zipArchive ?? throw new ArgumentNullException(nameof(zipArchive));
@@ -43,7 +46,7 @@ public class AsiceArchive : IDisposable
 
         // The certificate holder and the signature file ref creator need to be
         // null at the same time and non-null at the same time:
-        if ((signatureCertificate == null) != (signatureFileRefCreator== null))
+        if ((signatureCertificate == null) != (signatureFileRefCreator == null))
         {
             var nullArgName = signatureCertificate == null
                 ? nameof(signatureCertificate)
@@ -56,6 +59,7 @@ public class AsiceArchive : IDisposable
 
         _signatureCertificate = signatureCertificate;
         _signatureFileRefCreator = signatureFileRefCreator;
+        _signatureCreator = signatureCreator;
 
         _logger = loggerFactory?.CreateLogger<AsiceArchive>() ?? LoggerFactory.Create(builder => builder.AddConsole()).CreateLogger<AsiceArchive>();
         _logger.LogDebug("Creating ASiC-e Zip");
@@ -65,6 +69,7 @@ public class AsiceArchive : IDisposable
         Stream zipOutStream,
         IManifestCreator creator,
         ISignatureFileRefCreator signatureFileRefCreator,
+        ISignatureCreator signatureCreator,
         ICertificateHolder signatureCertificateHolder,
         ILoggerFactory loggerFactory = null)
     {
@@ -85,7 +90,7 @@ public class AsiceArchive : IDisposable
 
         // The certificate holder and the signature file ref creator need to be
         // null at the same time and non-null at the same time:
-        if ((signatureCertificateHolder == null) != (signatureFileRefCreator== null))
+        if ((signatureCertificateHolder == null) != (signatureFileRefCreator == null))
         {
             var nullArgName = signatureCertificateHolder == null
                 ? nameof(signatureCertificateHolder)
@@ -98,6 +103,7 @@ public class AsiceArchive : IDisposable
 
         _signatureCertificate = signatureCertificateHolder;
         _signatureFileRefCreator = signatureFileRefCreator;
+        _signatureCreator = signatureCreator;
 
         _logger = loggerFactory?.CreateLogger<AsiceArchive>() ?? LoggerFactory.Create(builder => builder.AddConsole()).CreateLogger<AsiceArchive>();
         _logger.LogDebug("Creating ASiC-e Zip");

--- a/KS.Fiks.ASiC-E/Model/AsiceArchive.cs
+++ b/KS.Fiks.ASiC-E/Model/AsiceArchive.cs
@@ -25,8 +25,6 @@ public class AsiceArchive : IDisposable
 
     private readonly MessageDigestAlgorithm _messageDigestAlgorithm;
 
-    private readonly ICertificateHolder _signatureCertificate;
-
     private readonly Queue<AsicePackageEntry> _entries = new Queue<AsicePackageEntry>();
 
     private readonly ILogger<AsiceArchive> _logger;
@@ -36,7 +34,6 @@ public class AsiceArchive : IDisposable
         IManifestCreator creator,
         ISignatureFileRefCreator signatureFileRefCreator,
         MessageDigestAlgorithm messageDigestAlgorithm,
-        ICertificateHolder signatureCertificate,
         ISignatureCreator signatureCreator,
         ILoggerFactory loggerFactory = null)
     {
@@ -44,20 +41,6 @@ public class AsiceArchive : IDisposable
         _manifestCreator = creator ?? throw new ArgumentNullException(nameof(creator));
         _messageDigestAlgorithm = messageDigestAlgorithm ?? throw new ArgumentNullException(nameof(messageDigestAlgorithm));
 
-        // The certificate holder and the signature file ref creator need to be
-        // null at the same time and non-null at the same time:
-        if ((signatureCertificate == null) != (signatureFileRefCreator == null))
-        {
-            var nullArgName = signatureCertificate == null
-                ? nameof(signatureCertificate)
-                : nameof(signatureFileRefCreator);
-
-            throw new ArgumentNullException(
-                nullArgName,
-                $"{nameof(signatureCertificate)} must be null if and only if {nameof(signatureFileRefCreator)} is null");
-        }
-
-        _signatureCertificate = signatureCertificate;
         _signatureFileRefCreator = signatureFileRefCreator;
         _signatureCreator = signatureCreator;
 
@@ -70,7 +53,6 @@ public class AsiceArchive : IDisposable
         IManifestCreator creator,
         ISignatureFileRefCreator signatureFileRefCreator,
         ISignatureCreator signatureCreator,
-        ICertificateHolder signatureCertificateHolder,
         ILoggerFactory loggerFactory = null)
     {
         if (zipOutStream == null)
@@ -88,20 +70,6 @@ public class AsiceArchive : IDisposable
         _manifestCreator = creator ?? throw new ArgumentNullException(nameof(creator));
         _messageDigestAlgorithm = MessageDigestAlgorithm.SHA256;
 
-        // The certificate holder and the signature file ref creator need to be
-        // null at the same time and non-null at the same time:
-        if ((signatureCertificateHolder == null) != (signatureFileRefCreator == null))
-        {
-            var nullArgName = signatureCertificateHolder == null
-                ? nameof(signatureCertificateHolder)
-                : nameof(signatureFileRefCreator);
-
-            throw new ArgumentNullException(
-                nullArgName,
-                $"{nameof(signatureCertificateHolder)} must be null if and only if {nameof(signatureFileRefCreator)} is null");
-        }
-
-        _signatureCertificate = signatureCertificateHolder;
         _signatureFileRefCreator = signatureFileRefCreator;
         _signatureCreator = signatureCreator;
 

--- a/KS.Fiks.ASiC-E/Model/AsiceConstants.cs
+++ b/KS.Fiks.ASiC-E/Model/AsiceConstants.cs
@@ -6,6 +6,10 @@ namespace KS.Fiks.ASiC_E.Model
     {
         public const string ContentTypeASiCe = "application/vnd.etsi.asic-e+zip";
         public const string ContentTypeSignature = "application/x-pkcs7-signature";
+
+        // TODO: Switch to using MediaTypeNames.Application.Xml instead of
+        // string literal if netstandard2.0 is dropped from TargetFrameworks:
+        public const string ContentTypeApplicationXml = "application/xml";
         public const string ContentTypeXml = MediaTypeNames.Text.Xml;
         public const string FileNameSignatureFile = "META-INF/signatures.xml";
         public const string FileNameMimeType = "mimetype";

--- a/KS.Fiks.ASiC-E/Model/AsiceConstants.cs
+++ b/KS.Fiks.ASiC-E/Model/AsiceConstants.cs
@@ -16,5 +16,6 @@ namespace KS.Fiks.ASiC_E.Model
         public const string SignatureAlgorithm = "SHA256WithRSA";
         public const string CadesManifestFilename = "META-INF/asicmanifest.xml";
         public static readonly MimeType MimeTypeCadesSignature = MimeType.ForString(ContentTypeSignature);
+        public static readonly MimeType MimeTypeXadesSignature = MimeType.ForString(ContentTypeApplicationXml);
     }
 }

--- a/KS.Fiks.ASiC-E/Model/AsicePackageEntry.cs
+++ b/KS.Fiks.ASiC-E/Model/AsicePackageEntry.cs
@@ -4,7 +4,19 @@ namespace KS.Fiks.ASiC_E.Model
 {
     public class AsicePackageEntry
     {
+        private static int identCounter = 0;
+
         public string FileName { get; }
+
+        public string ID
+        {
+            get
+            {
+                return $"ID_{id}";
+            }
+        }
+
+        private readonly int id;
 
         public MimeType Type { get; }
 
@@ -18,6 +30,7 @@ namespace KS.Fiks.ASiC_E.Model
             Type = type ?? throw new ArgumentNullException(nameof(type));
             MessageDigestAlgorithm = messageDigestAlgorithm ??
                                      throw new ArgumentNullException(nameof(messageDigestAlgorithm));
+            id = identCounter++;
         }
     }
 }

--- a/KS.Fiks.ASiC-E/Model/ManifestContainer.cs
+++ b/KS.Fiks.ASiC-E/Model/ManifestContainer.cs
@@ -11,6 +11,8 @@ namespace KS.Fiks.ASiC_E.Model
 
         public IEnumerable<byte> Data { get; }
 
+        public AsicePackageEntry PackageEntry { get; set; }
+
         public ManifestSpec ManifestSpec { get; }
 
         public ManifestContainer(string fileName, IEnumerable<byte> data, SignatureFileRef signatureFileRef, ManifestSpec manifestSpec)

--- a/KS.Fiks.ASiC-E/Model/SignatureFileRef.cs
+++ b/KS.Fiks.ASiC-E/Model/SignatureFileRef.cs
@@ -6,5 +6,10 @@ namespace KS.Fiks.ASiC_E.Model
             : base(fileName, AsiceConstants.MimeTypeCadesSignature)
         {
         }
+
+        public SignatureFileRef(string fileName, MimeType mimeType)
+            : base(fileName, mimeType)
+        {
+        }
     }
 }

--- a/KS.Fiks.ASiC-E/Sign/CadesSignature.cs
+++ b/KS.Fiks.ASiC-E/Sign/CadesSignature.cs
@@ -3,9 +3,9 @@ using KS.Fiks.ASiC_E.Model;
 
 namespace KS.Fiks.ASiC_E.Sign
 {
-    public static class CadesSignature
+    public class CadesSignature : ISignatureFileRefCreator
     {
-        public static SignatureFileRef CreateSignatureRef()
+        public SignatureFileRef CreateSignatureRef()
         {
             var uuid = Guid.NewGuid().ToString();
             return new SignatureFileRef($"META-INF/signature-{uuid}.p7s");

--- a/KS.Fiks.ASiC-E/Sign/ISignatureCreator.cs
+++ b/KS.Fiks.ASiC-E/Sign/ISignatureCreator.cs
@@ -6,8 +6,8 @@ namespace KS.Fiks.ASiC_E.Sign
 {
     public interface ISignatureCreator
     {
-        SignatureFileContainer CreateSignatureFile(IEnumerable<AsicePackageEntry> asicPackageEntries);
-
-        SignatureFileContainer CreateCadesSignatureFile(ManifestContainer manifestContainer);
+        SignatureFileContainer CreateSignatureFile(
+            ManifestContainer manifestContainer,
+            IEnumerable<AsicePackageEntry> asicPackageEntries);
     }
 }

--- a/KS.Fiks.ASiC-E/Sign/ISignatureFileRefCreator.cs
+++ b/KS.Fiks.ASiC-E/Sign/ISignatureFileRefCreator.cs
@@ -1,0 +1,9 @@
+﻿using KS.Fiks.ASiC_E.Model;
+
+namespace KS.Fiks.ASiC_E.Sign
+{
+    public interface ISignatureFileRefCreator
+    {
+        SignatureFileRef CreateSignatureRef();
+    }
+}

--- a/KS.Fiks.ASiC-E/Sign/SignatureCreator.cs
+++ b/KS.Fiks.ASiC-E/Sign/SignatureCreator.cs
@@ -22,12 +22,9 @@ namespace KS.Fiks.ASiC_E.Sign
             return new SignatureCreator(certificateHolder);
         }
 
-        public SignatureFileContainer CreateSignatureFile(IEnumerable<AsicePackageEntry> asicPackageEntries)
-        {
-            throw new NotImplementedException();
-        }
-
-        public SignatureFileContainer CreateCadesSignatureFile(ManifestContainer manifestContainer)
+        public SignatureFileContainer CreateSignatureFile(
+            ManifestContainer manifestContainer,
+            IEnumerable<AsicePackageEntry> asicPackageEntries)
         {
             var signedDataGenerator = new CmsSignedDataGenerator();
             signedDataGenerator.AddSigner(

--- a/KS.Fiks.ASiC-E/Sign/XadesSignature.cs
+++ b/KS.Fiks.ASiC-E/Sign/XadesSignature.cs
@@ -1,0 +1,14 @@
+﻿using KS.Fiks.ASiC_E.Model;
+
+namespace KS.Fiks.ASiC_E.Sign
+{
+    public class XadesSignature : ISignatureFileRefCreator
+    {
+        public SignatureFileRef CreateSignatureRef()
+        {
+            return new SignatureFileRef(
+                AsiceConstants.FileNameSignatureFile,
+                AsiceConstants.MimeTypeXadesSignature);
+        }
+    }
+}

--- a/KS.Fiks.ASiC-E/Sign/XadesSignatureCreator.cs
+++ b/KS.Fiks.ASiC-E/Sign/XadesSignatureCreator.cs
@@ -1,0 +1,416 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+using KS.Fiks.ASiC_E.Crypto;
+using KS.Fiks.ASiC_E.Model;
+using Org.BouncyCastle.Asn1;
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Operators;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.Security;
+using Org.BouncyCastle.X509;
+
+namespace KS.Fiks.ASiC_E.Sign
+{
+    public class XadesSignatureCreator : ISignatureCreator
+    {
+        public static XadesSignatureCreator Create(
+            ICertificateHolder certificateHolder)
+        {
+            return new XadesSignatureCreator(certificateHolder);
+        }
+
+        // Misc:
+        private const string Iso8601DateTimeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffZ";
+        private const string SignedPropertiesType = "http://uri.etsi.org/01903#SignedProperties";
+
+        // URIs that denote specific standardized algorithms:
+        private const string AlgoXmlEncSha256 = "http://www.w3.org/2001/04/xmlenc#sha256";
+        private const string AlgoXmlC14nIncl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+        private const string AlgoXmlDsigMoreRsaSha256 = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+        private const string AlgoXmlDsigSha1 = "http://www.w3.org/2000/09/xmldsig#sha1";
+
+        // Algorithm names that BouncyCastle accepts in certain method calls:
+        private const string AlgoSha1 = "SHA-1";
+        private const string AlgoSha256 = "SHA-256";
+        private const string AlgoSha256WithRsa = "SHA256withRSA";
+
+        // DS tag inventory that is used:
+        private const string TagC14nMethod = "CanonicalizationMethod";
+        private const string TagSignedInfo = "SignedInfo";
+        private const string TagDigestMethod = "DigestMethod";
+        private const string TagDigestValue = "DigestValue";
+        private const string TagSignatureMethod = "SignatureMethod";
+        private const string TagKeyInfo = "KeyInfo";
+        private const string TagObject = "Object";
+        private const string TagReference = "Reference";
+        private const string TagSignature = "Signature";
+        private const string TagSignatureValue = "SignatureValue";
+        private const string TagX509Data = "X509Data";
+        private const string TagX509Certificate = "X509Certificate";
+        private const string TagX509IssuerName = "X509IssuerName";
+        private const string TagX509SerialNumber = "X509SerialNumber";
+        private const string TagTransform = "Transform";
+        private const string TagTransforms = "Transforms";
+
+        // XAdES tag inventory that is used:
+        private const string TagCert = "Cert";
+        private const string TagCertDigest = "CertDigest";
+        private const string TagDataObjectFormat = "DataObjectFormat";
+        private const string TagIssuerSerial = "IssuerSerial";
+        private const string TagMimeType = "MimeType";
+        private const string TagQualifyingProperties = "QualifyingProperties";
+        private const string TagSignedDataObjectProperties = "SignedDataObjectProperties";
+        private const string TagSignedProperties = "SignedProperties";
+        private const string TagSignedSignatureProperties = "SignedSignatureProperties";
+        private const string TagSigningCertificate = "SigningCertificate";
+        private const string TagSigningTime = "SigningTime";
+        private const string TagXadesSignatures = "XAdESSignatures";
+
+        // Attribute names that are used:
+        private const string AttrAlgorithm = "Algorithm";
+        private const string AttrId = "Id";
+        private const string AttrObjectReference = "ObjectReference";
+        private const string AttrTarget = "Target";
+        private const string AttrType = "Type";
+        private const string AttrURI = "URI";
+
+        // Fragment identifiers that are used:
+        private const string FragmentIdentSignature = "Signature";
+        private const string FragmentIdentSignedProperties = "SignedProperties";
+
+        // XML namespace prefixes that will be used outside of the
+        // QualifyingProperties element:
+        private const string Etsi121 = ""; // default in root element
+        private const string Dsig = "ds"; // default in only child of root element
+
+        // XML namespaces prefixes used at or below the
+        // QualifyingProperties element in the document tree.
+        private const string NestedEtsi132 = ""; // default in subtree
+        private const string NestedDsig = "dsig";
+
+        // XML attribute name for specifying default namespace:
+        private const string Xmlns = "xmlns";
+
+        // XML namespace prefix-to-uri mapping for the root element
+        // and the first-level Signature element, although Signature,
+        // which is a direct child of the root, resets the default
+        // namespace from Etsi121 to Dsig:
+        private static readonly Dictionary<string, XNamespace> Nsmap = new()
+        {
+            [Etsi121] = "http://uri.etsi.org/2918/v1.2.1#", // default in root, only used for root
+            [Dsig] = "http://www.w3.org/2000/09/xmldsig#", // default in Signature, the only child of root
+        };
+
+        // XML namespace prefix-to-uri mapping for elements
+        // starting at the QualifyingProperties element:
+        private static readonly Dictionary<string, XNamespace> NestedNsmap = new()
+        {
+            [NestedEtsi132] = "http://uri.etsi.org/01903/v1.3.2#", // default in QualifyingProperties
+            [NestedDsig] = "http://www.w3.org/2000/09/xmldsig#",
+        };
+
+        private readonly ICertificateHolder _certificateHolder;
+
+        private static byte[] MakeHash(byte[] bytes, string algorithm)
+        {
+            IDigest digest = DigestUtilities.GetDigest(algorithm);
+            digest.BlockUpdate(bytes, 0, bytes.Length);
+            byte[] hash = new byte[digest.GetDigestSize()];
+            digest.DoFinal(hash, 0);
+            return hash;
+        }
+
+        private static string SignXml(
+            XElement signedInfoElement,
+            AsymmetricKeyParameter asymKeyParam)
+        {
+            var c14n = CanonicalizeSubtree(signedInfoElement);
+
+            // Sign it using BouncyCastle
+            var signer = new Asn1SignatureFactory(
+                AlgoSha256WithRsa,
+                asymKeyParam);
+
+            var sigGen = signer.CreateCalculator();
+            sigGen.Stream.Write(c14n, 0, c14n.Length);
+            sigGen.Stream.Flush();
+            byte[] signature = ((IBlockResult)sigGen.GetResult()).Collect();
+
+            return Convert.ToBase64String(signature);
+        }
+
+        // This works around a limitation in a Norwegian DPI vendor, Digipost, where
+        // RDN (relative distinguised name) for the organization identifier needs to
+        // be written using the older "OID.2.5.4.97=<value>" syntax rather than the
+        // newer "organizationIdentifier=<value>" syntax.
+        private static string FindCertificateIssuerName(X509Certificate pubCert)
+        {
+            X509Name issuer = pubCert.IssuerDN;
+            IList<DerObjectIdentifier> oids = issuer.GetOidList();
+            IList<string> values = issuer.GetValueList();
+
+            var newOids = new List<DerObjectIdentifier>();
+            var newValues = new List<string>();
+
+            string oidStr = "2.5.4.97";
+
+            for (int i = 0; i < oids.Count; i++)
+            {
+                var oid = oids[i];
+                var val = values[i];
+
+                // If the OID is 2.5.4.97 (meaning organizationIdentifier),
+                // make sure it is written as "OID.2.5.4.97=<value>" instead
+                // of "organizationIdentifier=<value>"
+                if (oid.Id == oidStr)
+                {
+                    newOids.Add(new DerObjectIdentifier(oidStr));
+                    newValues.Add(val);
+                }
+                else
+                {
+                    newOids.Add(oid);
+                    newValues.Add(val);
+                }
+            }
+
+            var customName = new X509Name(newOids, newValues);
+
+            string issuerString = customName.ToString(
+                X509Name.DefaultReverse,
+                new Dictionary<DerObjectIdentifier, string>());
+
+            return issuerString;
+        }
+
+        private static byte[] CanonicalizeSubtree(XNode node)
+        {
+            var xmlDoc = new XmlDocument();
+
+            using (var reader = node.CreateReader())
+            {
+                xmlDoc.Load(reader);
+            }
+
+            var transform = new System.Security.Cryptography.Xml.XmlDsigC14NTransform();
+            transform.LoadInput(xmlDoc);
+
+            using var stream = (Stream)transform.GetOutput(typeof(Stream));
+            using var ms = new MemoryStream();
+            stream.CopyTo(ms);
+            return ms.ToArray();
+        }
+
+        private static string MakeFragmentID(string id)
+            => "#" + id;
+
+        private static XDocument CreateXadesDocument(
+            AsymmetricKeyParameter privateKey,
+            IEnumerable<string> publicKeys,
+            string publicCertificateHash,
+            string issuerStr,
+            string serialNumberStr,
+            IEnumerable<AsicePackageEntry> entries,
+            AsicePackageEntry manifestEntry,
+            DateTime timeOfSigning)
+        {
+            string signingTimestamp = timeOfSigning.ToString(
+                Iso8601DateTimeFormat,
+                CultureInfo.InvariantCulture);
+
+            // Specific StyleCop rules are disabled for the area where the
+            // XML tree for the XAdES signature XML file is created using
+            // System.Linq.Xml in order to benefit from the ability in that
+            // library to create XML with deeply nested constructor calls
+            // that directly reflect the nesting structure of the XML itself.
+            // Also, the end-parenthesis characters are placed on their own
+            // line, with a comment about which node it terminates, as this
+            // proved useful while building this XML tree.
+            #pragma warning disable SA1009, SA1111, SA1115, SA1116, SA1117, SA1118
+
+            var signedProps = new XElement(NestedNsmap[NestedEtsi132] + TagSignedProperties,
+                new XAttribute(Xmlns, NestedNsmap[NestedEtsi132]),
+                new XAttribute(XNamespace.Xmlns + NestedDsig, NestedNsmap[NestedDsig]),
+                new XAttribute(AttrId, FragmentIdentSignedProperties),
+                new XElement(NestedNsmap[NestedEtsi132] + TagSignedSignatureProperties,
+                    new XElement(NestedNsmap[NestedEtsi132] + TagSigningTime, signingTimestamp),
+                    new XElement(NestedNsmap[NestedEtsi132] + TagSigningCertificate,
+                        new XElement(NestedNsmap[NestedEtsi132] + TagCert,
+                            new XElement(NestedNsmap[NestedEtsi132] + TagCertDigest,
+                                new XElement(NestedNsmap[NestedDsig] + TagDigestMethod,
+                                    new XAttribute(AttrAlgorithm, AlgoXmlDsigSha1)),
+                                new XElement(NestedNsmap[NestedDsig] + TagDigestValue, publicCertificateHash)
+                            ), // CertDigest
+                            new XElement(NestedNsmap[NestedEtsi132] + TagIssuerSerial,
+                                new XElement(NestedNsmap[NestedDsig] + TagX509IssuerName, issuerStr),
+                                new XElement(NestedNsmap[NestedDsig] + TagX509SerialNumber, serialNumberStr)
+                            ) // IssuerSerial
+                        ) // Cert
+                    ) // SigningCertificate
+                ), // SignedSignatureProperties
+                new XElement(NestedNsmap[NestedEtsi132] + TagSignedDataObjectProperties,
+                    entries.Select(entry => new XElement(NestedNsmap[NestedEtsi132] + TagDataObjectFormat,
+                        new XAttribute(AttrObjectReference, MakeFragmentID(entry.ID)),
+                        new XElement(NestedNsmap[NestedEtsi132] + TagMimeType, entry.Type.ToString())
+                    )), // DataObjectFormat and pkgEntries.Select
+                    new XElement(NestedNsmap[NestedEtsi132] + TagDataObjectFormat,
+                        new XAttribute(AttrObjectReference, MakeFragmentID(manifestEntry.ID)),
+                        new XElement(NestedNsmap[NestedEtsi132] + TagMimeType, AsiceConstants.ContentTypeApplicationXml)
+                    ) // DataObjectFormat
+                ) // SignedDataObjectProperties
+            ); // SignedProperties
+
+            byte[] canonicalSignedProps = CanonicalizeSubtree(signedProps);
+            byte[] signedPropsHash = MakeHash(canonicalSignedProps, AlgoSha256);
+            string signedPropsHashBase64 = Convert.ToBase64String(signedPropsHash);
+
+            var signedInfo = new XElement(Nsmap[Dsig] + TagSignedInfo,
+                new XElement(Nsmap[Dsig] + TagC14nMethod,
+                    new XAttribute(AttrAlgorithm, AlgoXmlC14nIncl)),
+                new XElement(Nsmap[Dsig] + TagSignatureMethod,
+                    new XAttribute(AttrAlgorithm, AlgoXmlDsigMoreRsaSha256)),
+                entries.Select(pkgEntry => new XElement(Nsmap[Dsig] + TagReference,
+                    new XAttribute(AttrId, pkgEntry.ID),
+                    new XAttribute(AttrURI, pkgEntry.FileName),
+                    new XElement(Nsmap[Dsig] + TagDigestMethod,
+                        new XAttribute(AttrAlgorithm, AlgoXmlEncSha256)),
+                    new XElement(Nsmap[Dsig] + TagDigestValue,
+                        Convert.ToBase64String(pkgEntry.Digest.GetDigest())
+                    ) // DigestValue
+                )), // Reference and pkgEntries.Select
+                new XElement(Nsmap[Dsig] + TagReference,
+                    new XAttribute(AttrId, manifestEntry.ID),
+                    new XAttribute(AttrURI, manifestEntry.FileName),
+                    new XElement(Nsmap[Dsig] + TagDigestMethod,
+                        new XAttribute(AttrAlgorithm, AlgoXmlEncSha256)),
+                    new XElement(Nsmap[Dsig] + TagDigestValue,
+                        Convert.ToBase64String(manifestEntry.Digest.GetDigest())
+                    ) // DigestValue
+                ), // Reference
+                new XElement(Nsmap[Dsig] + TagReference,
+                    new XAttribute(AttrType, SignedPropertiesType),
+                    new XAttribute(AttrURI, MakeFragmentID(FragmentIdentSignedProperties)),
+                    new XElement(Nsmap[Dsig] + TagTransforms,
+                        new XElement(Nsmap[Dsig] + TagTransform,
+                            new XAttribute(AttrAlgorithm, AlgoXmlC14nIncl)
+                        ) // Transform
+                    ), // Transforms
+                    new XElement(Nsmap[Dsig] + TagDigestMethod,
+                        new XAttribute(AttrAlgorithm, AlgoXmlEncSha256)),
+                    new XElement(Nsmap[Dsig] + TagDigestValue, signedPropsHashBase64)
+                ) // Reference
+            ); // SignedInfo
+
+            var signatureValue = SignXml(signedInfo, privateKey);
+
+            return new XDocument(
+                new XElement(Nsmap[Etsi121] + TagXadesSignatures,
+                    new XAttribute(Xmlns, Nsmap[Etsi121]),
+                    new XElement(Nsmap[Dsig] + TagSignature,
+                        new XAttribute(Xmlns, Nsmap[Dsig]),
+                        new XAttribute(AttrId, FragmentIdentSignature),
+                        signedInfo,
+                        new XElement(Nsmap[Dsig] + TagSignatureValue, signatureValue),
+                        new XElement(Nsmap[Dsig] + TagKeyInfo,
+                            new XElement(Nsmap[Dsig] + TagX509Data,
+                                publicKeys.Select(key => new XElement(Nsmap[Dsig] + TagX509Certificate,
+                                    key
+                                )) // X509Certificate and publicKeys.Select
+                            ) // X509Data
+                        ), // KeyInfo
+                        new XElement(Nsmap[Dsig] + TagObject,
+                            new XElement(NestedNsmap[NestedEtsi132] + TagQualifyingProperties,
+                                new XAttribute(Xmlns, NestedNsmap[NestedEtsi132]),
+                                new XAttribute(XNamespace.Xmlns + NestedDsig, NestedNsmap[NestedDsig]),
+                                new XAttribute(AttrTarget, MakeFragmentID(FragmentIdentSignature)),
+                                signedProps
+                            ) // QualifyingProperties
+                        ) // Object
+                    ) // Signature
+                ) // XAdESSignature
+            ); // end of document
+            #pragma warning restore SA1009, SA1111, SA1116, SA1117, SA1118
+
+            // The returned XML tree contains some redundant XML namespace declarations,
+            // which was difficult to avoid given the need to canonicalize and hash a
+            // subtree (signedProps) before adding both the hash and the subtree in the
+            // final document. The canonicalization requires the namespaces to be present
+            // on the subtree, but the QualifyingProperties element also happens to come
+            // from the same namespace, so the declarations are repeated between that node
+            // and the root node of the subtree.
+            //
+            // The initial motivation for adding XAdES support has been to send messages
+            // to Norway's DPI system, which has two commercial vendors. They both
+            // rejected the signature in all attempts to simplify the namespace
+            // declarations.
+        }
+
+        public XadesSignatureCreator(
+            ICertificateHolder certificateHolder)
+        {
+            _certificateHolder = certificateHolder ??
+                throw new ArgumentNullException(nameof(certificateHolder));
+        }
+
+        public SignatureFileContainer CreateSignatureFile(
+            ManifestContainer manifestContainer,
+            IEnumerable<AsicePackageEntry> asicPackageEntries)
+        {
+            var settings = new XmlWriterSettings
+            {
+                Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                Indent = false,
+            };
+
+            var pubCert = _certificateHolder.GetPublicCertificate();
+            IReadOnlyList<X509Certificate> chain = _certificateHolder.GetCertificateChain();
+
+            byte[] pubCertDer = pubCert.GetEncoded();
+            string pubCertStr = Convert.ToBase64String(pubCertDer);
+
+            var completeChain = new List<string> { pubCertStr };
+            completeChain.AddRange(
+                chain.Select(
+                    cert => Convert.ToBase64String(
+                        cert.GetEncoded())));
+
+            byte[] pucCertHash = MakeHash(pubCertDer, AlgoSha1);
+            string certHash = Convert.ToBase64String(pucCertHash);
+            string issuerStr = FindCertificateIssuerName(pubCert);
+            BigInteger serialNumber = pubCert.SerialNumber;
+            string serialNumberStr = serialNumber.ToString();
+
+            XDocument doc = CreateXadesDocument(
+                _certificateHolder.GetPrivateKey(),
+                completeChain,
+                certHash,
+                issuerStr,
+                serialNumberStr,
+                asicPackageEntries,
+                manifestContainer.PackageEntry,
+                DateTime.UtcNow);
+
+            byte[] bytes;
+            using (var memStream = new MemoryStream())
+            {
+                using (var writer = XmlWriter.Create(memStream, settings))
+                {
+                    doc.Save(writer);
+                }
+
+                bytes = memStream.ToArray();
+            }
+
+            return new SignatureFileContainer(
+                manifestContainer.SignatureFileRef,
+                bytes);
+        }
+    }
+}

--- a/KS.Fiks.ASiC-E/Sign/XadesSignatureCreator.cs
+++ b/KS.Fiks.ASiC-E/Sign/XadesSignatureCreator.cs
@@ -21,9 +21,10 @@ namespace KS.Fiks.ASiC_E.Sign
     public class XadesSignatureCreator : ISignatureCreator
     {
         public static XadesSignatureCreator Create(
-            ICertificateHolder certificateHolder)
+            ICertificateHolder certificateHolder,
+            Func<DateTime> getUtcNow)
         {
-            return new XadesSignatureCreator(certificateHolder);
+            return new XadesSignatureCreator(certificateHolder, getUtcNow);
         }
 
         // Misc:
@@ -117,6 +118,7 @@ namespace KS.Fiks.ASiC_E.Sign
         };
 
         private readonly ICertificateHolder _certificateHolder;
+        private readonly Func<DateTime> _getUtcNow;
 
         private static byte[] MakeHash(byte[] bytes, string algorithm)
         {
@@ -353,8 +355,18 @@ namespace KS.Fiks.ASiC_E.Sign
         }
 
         public XadesSignatureCreator(
-            ICertificateHolder certificateHolder)
+            ICertificateHolder certificateHolder,
+            Func<DateTime> getUtcNow)
         {
+            if (getUtcNow == null)
+            {
+                _getUtcNow = () => DateTime.UtcNow;
+            }
+            else
+            {
+                _getUtcNow = getUtcNow;
+            }
+
             _certificateHolder = certificateHolder ??
                 throw new ArgumentNullException(nameof(certificateHolder));
         }

--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ to be functionally compliant with the [DIFI ASiC library for Java](//github.com/
 
 Currently implements:
 * building ASiC-E packages containing binaries containing CAdES descriptor
+* building ASiC-E packages containing XAdES signatures
+* building ASiC-E packages with custom manifests
 * signing packages using private/public keys in PEM files
 * reading ASiC-E packages including exposing CAdES signatures (only CAdES manifest descriptor supported for now)
 
 TODO:
 * support for specifying OASIS manifest 
-* support XAdES signatures
+* support veryfying XAdES signatures
 
 ## Examples
 ### Create ASiC-E package containing single file


### PR DESCRIPTION
As discussed last week, here is my work in implementing XAdES signature support in the library.

As we touched on, I have added an overload of the `Create()` method in `AsiceBuilder` that maintains the same signature as before these changes. As we agreed on, I have marked it as `Obsolete`.

This PR does not contain signature verification, only actual signing.

It also does not contain any XAdES-specific manifest format, since my usecase involves a custom/non-standard manifest format. I have access to real, live services that I have tested the XAdES signatures against, but these do not enforce whatever manifest format is normally used in conjunction with XAdES; instead they only require the non-standard manifest format.

The non-standard manifest format is of course not part of this PR. Instead, the `AsiceBuilder.Create()` method has gained an optional parameter that allows library users to pass in their own implementation of the `IManifestCreator` interface. Our own use does exactly this.